### PR TITLE
Feat/방명록 불러오기, 아바타 별명 변경 api

### DIFF
--- a/src/main/java/com/example/cp_main_be/domain/admin/presentation/AdminController.java
+++ b/src/main/java/com/example/cp_main_be/domain/admin/presentation/AdminController.java
@@ -106,25 +106,25 @@ public class AdminController {
     QuizOptions quizOptions = adminService.createQuizOption(requestDTO);
     return ResponseEntity.ok(ApiResponse.success(quizOptions));
   }
-
-  @PostMapping("/avatar-master")
-  @Operation(summary = "새 아바타 마스터 등록 API")
-  public ResponseEntity<ApiResponse<AdminResponseDTO.PlantMasterResDTO>> createNewPlant(
-      AdminRequestDTO.CreatePlantMasterRequestDTO requestDTO) {
-    PlantMasters plantMaster = adminService.createNewPlant(requestDTO);
-    AdminResponseDTO.PlantMasterResDTO result = PlantMasters.toPlantMasterResDTO(plantMaster);
-    return ResponseEntity.ok(ApiResponse.success(result));
-  }
-
-  @PutMapping("/plants/{avatar-master-id}")
-  @Operation(summary = "아바타 마스터 정보 수정 API")
-  public ResponseEntity<ApiResponse<AdminResponseDTO.PlantMasterResDTO>> updatePlantMasters(
-      @PathVariable(name = "avatar-master-id") Long plantId,
-      AdminRequestDTO.UpdatePlantMasterRequestDTO requestDTO) {
-    PlantMasters plantMaster = adminService.updatePlantMasters(plantId, requestDTO);
-    AdminResponseDTO.PlantMasterResDTO result = PlantMasters.toPlantMasterResDTO(plantMaster);
-    return ResponseEntity.ok(ApiResponse.success(result));
-  }
+//
+//  @PostMapping("/avatar-master")
+//  @Operation(summary = "새 아바타 마스터 등록 API")
+//  public ResponseEntity<ApiResponse<AdminResponseDTO.PlantMasterResDTO>> createNewPlant(
+//      AdminRequestDTO.CreatePlantMasterRequestDTO requestDTO) {
+//    PlantMasters plantMaster = adminService.createNewPlant(requestDTO);
+//    AdminResponseDTO.PlantMasterResDTO result = PlantMasters.toPlantMasterResDTO(plantMaster);
+//    return ResponseEntity.ok(ApiResponse.success(result));
+//  }
+//
+//  @PutMapping("/plants/{avatar-master-id}")
+//  @Operation(summary = "아바타 마스터 정보 수정 API")
+//  public ResponseEntity<ApiResponse<AdminResponseDTO.PlantMasterResDTO>> updatePlantMasters(
+//      @PathVariable(name = "avatar-master-id") Long plantId,
+//      AdminRequestDTO.UpdatePlantMasterRequestDTO requestDTO) {
+//    PlantMasters plantMaster = adminService.updatePlantMasters(plantId, requestDTO);
+//    AdminResponseDTO.PlantMasterResDTO result = PlantMasters.toPlantMasterResDTO(plantMaster);
+//    return ResponseEntity.ok(ApiResponse.success(result));
+//  }
 
   @GetMapping("/reports")
   @Operation(summary = "신고 목록 조회 API")

--- a/src/main/java/com/example/cp_main_be/domain/admin/presentation/AdminController.java
+++ b/src/main/java/com/example/cp_main_be/domain/admin/presentation/AdminController.java
@@ -16,7 +16,6 @@ package com.example.cp_main_be.domain.admin.presentation;
 import com.example.cp_main_be.domain.admin.dto.AdminRequestDTO;
 import com.example.cp_main_be.domain.admin.dto.AdminResponseDTO;
 import com.example.cp_main_be.domain.admin.service.AdminService;
-import com.example.cp_main_be.domain.garden.plant_masters.domain.PlantMasters;
 import com.example.cp_main_be.domain.member.user.domain.User;
 import com.example.cp_main_be.domain.mission.daily_keywords.domain.DailyKeywords;
 import com.example.cp_main_be.domain.mission.daily_mission_master.domain.DailyMissionMaster;
@@ -101,25 +100,6 @@ public class AdminController {
       AdminRequestDTO.CreateQuizRequestDTO requestDTO) {
     QuizOptions quizOptions = adminService.createQuizOption(requestDTO);
     return ResponseEntity.ok(ApiResponse.success(quizOptions));
-  }
-
-  @PostMapping("/plants")
-  @Operation(summary = "새 식물 등록 API")
-  public ResponseEntity<ApiResponse<AdminResponseDTO.PlantMasterResDTO>> createNewPlant(
-      AdminRequestDTO.CreatePlantMasterRequestDTO requestDTO) {
-    PlantMasters plantMaster = adminService.createNewPlant(requestDTO);
-    AdminResponseDTO.PlantMasterResDTO result = PlantMasters.toPlantMasterResDTO(plantMaster);
-    return ResponseEntity.ok(ApiResponse.success(result));
-  }
-
-  @PutMapping("/plants/{plantId}")
-  @Operation(summary = "식물 정보 수정 API")
-  public ResponseEntity<ApiResponse<AdminResponseDTO.PlantMasterResDTO>> updatePlantMasters(
-      @PathVariable(name = "plantId") Long plantId,
-      AdminRequestDTO.UpdatePlantMasterRequestDTO requestDTO) {
-    PlantMasters plantMaster = adminService.updatePlantMasters(plantId, requestDTO);
-    AdminResponseDTO.PlantMasterResDTO result = PlantMasters.toPlantMasterResDTO(plantMaster);
-    return ResponseEntity.ok(ApiResponse.success(result));
   }
 
   @GetMapping("/reports")

--- a/src/main/java/com/example/cp_main_be/domain/admin/presentation/AdminController.java
+++ b/src/main/java/com/example/cp_main_be/domain/admin/presentation/AdminController.java
@@ -29,6 +29,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -103,8 +104,8 @@ public class AdminController {
     return ResponseEntity.ok(ApiResponse.success(quizOptions));
   }
 
-  @PostMapping("/plants")
-  @Operation(summary = "새 식물 등록 API")
+  @PostMapping("/avatar-master")
+  @Operation(summary = "새 아바타 마스터 등록 API")
   public ResponseEntity<ApiResponse<AdminResponseDTO.PlantMasterResDTO>> createNewPlant(
       AdminRequestDTO.CreatePlantMasterRequestDTO requestDTO) {
     PlantMasters plantMaster = adminService.createNewPlant(requestDTO);
@@ -112,10 +113,10 @@ public class AdminController {
     return ResponseEntity.ok(ApiResponse.success(result));
   }
 
-  @PutMapping("/plants/{plantId}")
-  @Operation(summary = "식물 정보 수정 API")
+  @PutMapping("/plants/{avatar-master-id}")
+  @Operation(summary = "아바타 마스터 정보 수정 API")
   public ResponseEntity<ApiResponse<AdminResponseDTO.PlantMasterResDTO>> updatePlantMasters(
-      @PathVariable(name = "plantId") Long plantId,
+      @PathVariable(name = "avatar-master-id") Long plantId,
       AdminRequestDTO.UpdatePlantMasterRequestDTO requestDTO) {
     PlantMasters plantMaster = adminService.updatePlantMasters(plantId, requestDTO);
     AdminResponseDTO.PlantMasterResDTO result = PlantMasters.toPlantMasterResDTO(plantMaster);
@@ -160,5 +161,11 @@ public class AdminController {
             .build();
 
     return ResponseEntity.ok(ApiResponse.success(reportResDTO));
+  }
+
+  @PostMapping(value = "/plant/delivery/", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  @Operation(summary = "택배로 받을 식물 사진 추가")
+  public ResponseEntity<ApiResponse<Boolean>> addDeliveryPlantImage(){
+
   }
 }

--- a/src/main/java/com/example/cp_main_be/domain/admin/presentation/AdminController.java
+++ b/src/main/java/com/example/cp_main_be/domain/admin/presentation/AdminController.java
@@ -16,6 +16,8 @@ package com.example.cp_main_be.domain.admin.presentation;
 import com.example.cp_main_be.domain.admin.dto.AdminRequestDTO;
 import com.example.cp_main_be.domain.admin.dto.AdminResponseDTO;
 import com.example.cp_main_be.domain.admin.service.AdminService;
+import com.example.cp_main_be.domain.delivery.domain.DeliveryPlant;
+import com.example.cp_main_be.domain.delivery.dto.request.DeliveryPlantRequest;
 import com.example.cp_main_be.domain.garden.plant_masters.domain.PlantMasters;
 import com.example.cp_main_be.domain.member.user.domain.User;
 import com.example.cp_main_be.domain.mission.daily_keywords.domain.DailyKeywords;
@@ -32,6 +34,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/v1/admin")
@@ -164,8 +167,9 @@ public class AdminController {
   }
 
   @PostMapping(value = "/plant/delivery/", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-  @Operation(summary = "택배로 받을 식물 사진 추가")
-  public ResponseEntity<ApiResponse<Boolean>> addDeliveryPlantImage(){
-
+  @Operation(summary = "택배로 받을 식물 추가")
+  public ResponseEntity<ApiResponse<DeliveryPlant>> addDeliveryPlant(@RequestParam MultipartFile file, @RequestBody DeliveryPlantRequest request) {
+      DeliveryPlant deliveryPlant = adminService.addDeliveryPlant(file,request);
+      return ResponseEntity.ok(ApiResponse.success(deliveryPlant));
   }
 }

--- a/src/main/java/com/example/cp_main_be/domain/admin/service/AdminService.java
+++ b/src/main/java/com/example/cp_main_be/domain/admin/service/AdminService.java
@@ -1,8 +1,8 @@
 package com.example.cp_main_be.domain.admin.service;
 
 import com.example.cp_main_be.domain.admin.dto.AdminRequestDTO;
-import com.example.cp_main_be.domain.garden.plant_masters.domain.PlantMasters;
-import com.example.cp_main_be.domain.garden.plant_masters.domain.repository.PlantMasterRepository;
+import com.example.cp_main_be.domain.delivery.domain.DeliveryPlant;
+import com.example.cp_main_be.domain.delivery.dto.request.DeliveryPlantRequest;
 import com.example.cp_main_be.domain.member.user.domain.User;
 import com.example.cp_main_be.domain.member.user.service.UserService;
 import com.example.cp_main_be.domain.mission.daily_keywords.domain.DailyKeywords;
@@ -15,9 +15,12 @@ import com.example.cp_main_be.domain.reports.domain.Reports;
 import com.example.cp_main_be.domain.reports.domain.repository.ReportRepository;
 import com.example.cp_main_be.domain.reports.enums.ReportStatus;
 import java.util.List;
+
+import com.example.cp_main_be.global.infra.S3Uploader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -26,10 +29,10 @@ public class AdminService {
 
   private final DailyMissionMastersRepository dailyMissionMastersRepository;
   private final DailyKeywordsRepository dailyKeywordsRepository;
-  private final PlantMasterRepository plantMasterRepository;
 
   private final UserService userService;
   private final ReportRepository reportRepository;
+  private final S3Uploader s3Uploader;
 
   public DailyMissionMaster createDailyMissionMasters(
       AdminRequestDTO.CreateMissionRequestDTO requestDTO) {
@@ -92,28 +95,6 @@ public class AdminService {
         .build();
   }
 
-  public PlantMasters createNewPlant(AdminRequestDTO.CreatePlantMasterRequestDTO requestDTO) {
-    PlantMasters plantMasters =
-        PlantMasters.builder()
-            .plantName(requestDTO.getPlantName())
-            .plantType(requestDTO.getPlantType())
-            .imageUrl(requestDTO.getImageUrl())
-            .description(requestDTO.getDescription())
-            .build();
-
-    return plantMasterRepository.save(plantMasters);
-  }
-
-  public PlantMasters updatePlantMasters(
-      Long plantId, AdminRequestDTO.UpdatePlantMasterRequestDTO requestDTO) {
-    PlantMasters plantMasters =
-        plantMasterRepository
-            .findById(plantId)
-            .orElseThrow(() -> new IllegalStateException("해당 ID를 가진 식물이 존재하지 않습니다."));
-    plantMasters.update(requestDTO);
-    return plantMasters;
-  }
-
   public List<Reports> getAllReports() {
     List<Reports> reports = reportRepository.findAll();
     return reports;
@@ -126,5 +107,13 @@ public class AdminService {
             .orElseThrow(() -> new RuntimeException("신고를 찾을 수 없습니다."));
     report.setStatus(reportStatus);
     return report;
+  }
+
+  public DeliveryPlant addDeliveryPlant(MultipartFile file, DeliveryPlantRequest request) {
+     String imageUrl = s3Uploader.upload(file, "/deliveryplant");
+      return DeliveryPlant.builder()
+              .name(request.getName())
+              .imageUrl(imageUrl)
+              .build();
   }
 }

--- a/src/main/java/com/example/cp_main_be/domain/admin/service/AdminService.java
+++ b/src/main/java/com/example/cp_main_be/domain/admin/service/AdminService.java
@@ -1,8 +1,6 @@
 package com.example.cp_main_be.domain.admin.service;
 
 import com.example.cp_main_be.domain.admin.dto.AdminRequestDTO;
-import com.example.cp_main_be.domain.garden.plant_masters.domain.PlantMasters;
-import com.example.cp_main_be.domain.garden.plant_masters.domain.repository.PlantMasterRepository;
 import com.example.cp_main_be.domain.member.user.domain.User;
 import com.example.cp_main_be.domain.member.user.service.UserService;
 import com.example.cp_main_be.domain.mission.daily_keywords.domain.DailyKeywords;
@@ -26,7 +24,6 @@ public class AdminService {
 
   private final DailyMissionMastersRepository dailyMissionMastersRepository;
   private final DailyKeywordsRepository dailyKeywordsRepository;
-  private final PlantMasterRepository plantMasterRepository;
 
   private final UserService userService;
   private final ReportRepository reportRepository;
@@ -90,28 +87,6 @@ public class AdminService {
         .optionOrder(requestDTO.getOptionOrder())
         .isCorrect(requestDTO.isCorrect())
         .build();
-  }
-
-  public PlantMasters createNewPlant(AdminRequestDTO.CreatePlantMasterRequestDTO requestDTO) {
-    PlantMasters plantMasters =
-        PlantMasters.builder()
-            .plantName(requestDTO.getPlantName())
-            .plantType(requestDTO.getPlantType())
-            .imageUrl(requestDTO.getImageUrl())
-            .description(requestDTO.getDescription())
-            .build();
-
-    return plantMasterRepository.save(plantMasters);
-  }
-
-  public PlantMasters updatePlantMasters(
-      Long plantId, AdminRequestDTO.UpdatePlantMasterRequestDTO requestDTO) {
-    PlantMasters plantMasters =
-        plantMasterRepository
-            .findById(plantId)
-            .orElseThrow(() -> new IllegalStateException("해당 ID를 가진 식물이 존재하지 않습니다."));
-    plantMasters.update(requestDTO);
-    return plantMasters;
   }
 
   public List<Reports> getAllReports() {

--- a/src/main/java/com/example/cp_main_be/domain/avatar/avatar/domain/AvatarMaster.java
+++ b/src/main/java/com/example/cp_main_be/domain/avatar/avatar/domain/AvatarMaster.java
@@ -5,6 +5,7 @@ import lombok.*;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/example/cp_main_be/domain/delivery/domain/DeliveryPlant.java
+++ b/src/main/java/com/example/cp_main_be/domain/delivery/domain/DeliveryPlant.java
@@ -1,0 +1,22 @@
+package com.example.cp_main_be.domain.delivery.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DeliveryPlant {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    @Column(name = "name")
+    private String name;
+}

--- a/src/main/java/com/example/cp_main_be/domain/delivery/domain/repository/DeliveryPlantRepository.java
+++ b/src/main/java/com/example/cp_main_be/domain/delivery/domain/repository/DeliveryPlantRepository.java
@@ -1,0 +1,7 @@
+package com.example.cp_main_be.domain.delivery.domain.repository;
+
+import com.example.cp_main_be.domain.delivery.domain.DeliveryPlant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DeliveryPlantRepository extends JpaRepository<DeliveryPlant, Long> {
+}

--- a/src/main/java/com/example/cp_main_be/domain/delivery/dto/request/DeliveryPlantRequest.java
+++ b/src/main/java/com/example/cp_main_be/domain/delivery/dto/request/DeliveryPlantRequest.java
@@ -1,0 +1,11 @@
+package com.example.cp_main_be.domain.delivery.dto.request;
+
+import jakarta.persistence.Column;
+import lombok.Getter;
+
+@Getter
+public class DeliveryPlantRequest {
+    //추가 가능
+    private String name;
+
+}

--- a/src/main/java/com/example/cp_main_be/domain/garden/plant_masters/domain/PlantMasters.java
+++ b/src/main/java/com/example/cp_main_be/domain/garden/plant_masters/domain/PlantMasters.java
@@ -14,7 +14,6 @@ import org.hibernate.annotations.CreationTimestamp;
 @AllArgsConstructor
 @NoArgsConstructor
 public class PlantMasters {
-
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "plant_master_id")

--- a/src/main/java/com/example/cp_main_be/domain/member/user/dto/request/AvatarChangeRequest.java
+++ b/src/main/java/com/example/cp_main_be/domain/member/user/dto/request/AvatarChangeRequest.java
@@ -1,6 +1,5 @@
 package com.example.cp_main_be.domain.member.user.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -10,5 +9,4 @@ public class AvatarChangeRequest {
 
   private String newAvatarUrl;
   private String newAvatarName;
-
 }

--- a/src/main/java/com/example/cp_main_be/domain/member/user/dto/request/AvatarChangeRequest.java
+++ b/src/main/java/com/example/cp_main_be/domain/member/user/dto/request/AvatarChangeRequest.java
@@ -7,6 +7,9 @@ import lombok.Setter;
 @Getter
 @Setter
 public class AvatarChangeRequest {
-  @NotBlank(message = "새로운 아바타 URL은 필수입니다.")
+
   private String newAvatarUrl;
+
+  private String newAvatarName;
+
 }

--- a/src/main/java/com/example/cp_main_be/domain/member/user/dto/request/AvatarChangeRequest.java
+++ b/src/main/java/com/example/cp_main_be/domain/member/user/dto/request/AvatarChangeRequest.java
@@ -9,7 +9,6 @@ import lombok.Setter;
 public class AvatarChangeRequest {
 
   private String newAvatarUrl;
-
   private String newAvatarName;
 
 }

--- a/src/main/java/com/example/cp_main_be/domain/member/user/presentation/UserController.java
+++ b/src/main/java/com/example/cp_main_be/domain/member/user/presentation/UserController.java
@@ -42,7 +42,7 @@ public class UserController {
   public ResponseEntity<ApiResponse<Void>> updateAvatar(
       @AuthenticationPrincipal User user, @RequestBody @Valid AvatarChangeRequest request) {
 
-    userService.updateAvatar(user.getId(), request.getNewAvatarUrl());
+    userService.updateAvatar(user.getId(), request);
     return ResponseEntity.ok(ApiResponse.success(null));
   }
 

--- a/src/main/java/com/example/cp_main_be/domain/member/user/presentation/UserController.java
+++ b/src/main/java/com/example/cp_main_be/domain/member/user/presentation/UserController.java
@@ -1,14 +1,17 @@
 package com.example.cp_main_be.domain.member.user.presentation;
 
 import com.example.cp_main_be.domain.member.user.domain.User;
+import com.example.cp_main_be.domain.member.user.domain.repository.UserRepository;
 import com.example.cp_main_be.domain.member.user.dto.request.AvatarChangeRequest;
 import com.example.cp_main_be.domain.member.user.dto.request.NicknameChangeRequest;
 import com.example.cp_main_be.domain.member.user.dto.response.UserRegisterResponse;
 import com.example.cp_main_be.domain.member.user.service.UserService;
 import com.example.cp_main_be.global.common.ApiResponse;
+import com.example.cp_main_be.global.exception.UserNotFoundException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.websocket.server.PathParam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -21,6 +24,7 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
   private final UserService userService;
+  private final UserRepository userRepository;
 
   //    @DeleteMapping("/register/nickname")
   //    public ResponseEntity<Void> delete(@RequestBody @Valid UserRequest userRequest) {
@@ -73,5 +77,16 @@ public class UserController {
       @AuthenticationPrincipal User user) {
     UserRegisterResponse.LevelStatusResponseDTO levelStatusResponseDTO = userService.getLevel(user);
     return ResponseEntity.ok(ApiResponse.success(levelStatusResponseDTO));
+  }
+  @Operation(summary = "유저 정보 조회", description = "유저 정보를 조회합니다")
+  @GetMapping("/{userId}")
+  public ResponseEntity<ApiResponse<UserRegisterResponse>> getUserInfo(
+          @PathParam("userId") Long userId) {
+    // SecurityContextHolder에서 현재 인증된 사용자(UUID)를 가져옴
+    User user = userRepository.findById(userId).orElseThrow(()->new UserNotFoundException("해당 유저를 찾을 수 없습니다."));
+    UserRegisterResponse userRegisterResponse =
+            new UserRegisterResponse(
+                    user.getId(), user.getNickname(), user.getUuid(), null, null); // 토큰은 응답에 포함하지 않음
+    return ResponseEntity.ok(ApiResponse.success(userRegisterResponse));
   }
 }

--- a/src/main/java/com/example/cp_main_be/domain/member/user/presentation/UserController.java
+++ b/src/main/java/com/example/cp_main_be/domain/member/user/presentation/UserController.java
@@ -40,7 +40,9 @@ public class UserController {
   @Operation(summary = "아바타 수정", description = "새로운 아바타 정보로 업데이트합니다")
   @PatchMapping("/users/me/{avatarId}")
   public ResponseEntity<ApiResponse<Void>> updateAvatar(
-      @AuthenticationPrincipal User user, @RequestBody @Valid AvatarChangeRequest request, @RequestParam("avatarId") Long avatarId) {
+      @AuthenticationPrincipal User user,
+      @RequestBody @Valid AvatarChangeRequest request,
+      @RequestParam("avatarId") Long avatarId) {
 
     userService.updateAvatar(user, request, avatarId);
     return ResponseEntity.ok(ApiResponse.success(null));

--- a/src/main/java/com/example/cp_main_be/domain/member/user/presentation/UserController.java
+++ b/src/main/java/com/example/cp_main_be/domain/member/user/presentation/UserController.java
@@ -38,11 +38,11 @@ public class UserController {
   }
 
   @Operation(summary = "아바타 수정", description = "새로운 아바타 정보로 업데이트합니다")
-  @PatchMapping("/users/me/avatar")
+  @PatchMapping("/users/me/{avatarId}")
   public ResponseEntity<ApiResponse<Void>> updateAvatar(
-      @AuthenticationPrincipal User user, @RequestBody @Valid AvatarChangeRequest request) {
+      @AuthenticationPrincipal User user, @RequestBody @Valid AvatarChangeRequest request, @RequestParam("avatarId") Long avatarId) {
 
-    userService.updateAvatar(user.getId(), request);
+    userService.updateAvatar(user, request, avatarId);
     return ResponseEntity.ok(ApiResponse.success(null));
   }
 
@@ -50,7 +50,7 @@ public class UserController {
   @PatchMapping("/users/me/nickname")
   public ResponseEntity<ApiResponse<Void>> updateNickname(
       @AuthenticationPrincipal User user, @RequestBody @Valid NicknameChangeRequest request) {
-    userService.updateNickname(user.getId(), request.getNewNickname());
+    userService.updateNickname(user, request.getNewNickname());
     return ResponseEntity.ok(ApiResponse.success(null));
   }
 

--- a/src/main/java/com/example/cp_main_be/domain/member/user/service/UserService.java
+++ b/src/main/java/com/example/cp_main_be/domain/member/user/service/UserService.java
@@ -1,7 +1,6 @@
 package com.example.cp_main_be.domain.member.user.service;
 
 import com.example.cp_main_be.domain.avatar.avatar.domain.Avatar;
-import com.example.cp_main_be.domain.avatar.avatar.domain.AvatarMaster;
 import com.example.cp_main_be.domain.avatar.avatar.domain.repository.AvatarRepository;
 import com.example.cp_main_be.domain.member.level.service.LevelService;
 import com.example.cp_main_be.domain.member.user.domain.User;
@@ -34,16 +33,16 @@ public class UserService {
   }
 
   public void updateAvatar(User user, AvatarChangeRequest request, Long avatarId) {
-    if(user == null) return;
-    Avatar avatar = avatarRepository.findById(avatarId)
+    if (user == null) return;
+    Avatar avatar =
+        avatarRepository
+            .findById(avatarId)
             .orElseThrow(() -> new AvatarNotFoundException("아바타를 찾을 수 없습니다."));
-    if(avatar == null) return;
-    if(request.getNewAvatarUrl() != null)
-    {
+    if (avatar == null) return;
+    if (request.getNewAvatarUrl() != null) {
       avatar.getAvatarMaster().setDefaultImageUrl(request.getNewAvatarUrl());
     }
-    if(request.getNewAvatarName() != null)
-    {
+    if (request.getNewAvatarName() != null) {
       avatar.setNickname(request.getNewAvatarName());
     }
     avatarRepository.save(avatar);

--- a/src/main/java/com/example/cp_main_be/domain/member/user/service/UserService.java
+++ b/src/main/java/com/example/cp_main_be/domain/member/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.example.cp_main_be.domain.member.user.service;
 import com.example.cp_main_be.domain.member.level.service.LevelService;
 import com.example.cp_main_be.domain.member.user.domain.User;
 import com.example.cp_main_be.domain.member.user.domain.repository.UserRepository;
+import com.example.cp_main_be.domain.member.user.dto.request.AvatarChangeRequest;
 import com.example.cp_main_be.domain.member.user.dto.response.UserRegisterResponse;
 import com.example.cp_main_be.global.exception.UserNotFoundException;
 import java.util.List;
@@ -27,12 +28,12 @@ public class UserService {
     levelService.checkLevelUp(user);
   }
 
-  public void updateAvatar(Long userId, String newAvatarUrl) {
+  public void updateAvatar(Long userId, AvatarChangeRequest request) {
     User user =
         userRepository
             .findById(userId)
             .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
-    user.updateProfile(null, newAvatarUrl);
+    user.updateProfile(null, request.getNewAvatarUrl());
     userRepository.save(user);
   }
 

--- a/src/main/java/com/example/cp_main_be/domain/member/user/service/UserService.java
+++ b/src/main/java/com/example/cp_main_be/domain/member/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.example.cp_main_be.domain.member.user.service;
 
 import com.example.cp_main_be.domain.avatar.avatar.domain.Avatar;
+import com.example.cp_main_be.domain.avatar.avatar.domain.AvatarMaster;
 import com.example.cp_main_be.domain.avatar.avatar.domain.repository.AvatarRepository;
 import com.example.cp_main_be.domain.member.level.service.LevelService;
 import com.example.cp_main_be.domain.member.user.domain.User;
@@ -39,9 +40,13 @@ public class UserService {
     if(avatar == null) return;
     if(request.getNewAvatarUrl() != null)
     {
-      Ava
+      avatar.getAvatarMaster().setDefaultImageUrl(request.getNewAvatarUrl());
     }
-    userRepository.save(user);
+    if(request.getNewAvatarName() != null)
+    {
+      avatar.setNickname(request.getNewAvatarName());
+    }
+    avatarRepository.save(avatar);
   }
 
   public void updateNickname(User user, String newNickname) {

--- a/src/main/java/com/example/cp_main_be/domain/member/user/service/UserService.java
+++ b/src/main/java/com/example/cp_main_be/domain/member/user/service/UserService.java
@@ -1,10 +1,13 @@
 package com.example.cp_main_be.domain.member.user.service;
 
+import com.example.cp_main_be.domain.avatar.avatar.domain.Avatar;
+import com.example.cp_main_be.domain.avatar.avatar.domain.repository.AvatarRepository;
 import com.example.cp_main_be.domain.member.level.service.LevelService;
 import com.example.cp_main_be.domain.member.user.domain.User;
 import com.example.cp_main_be.domain.member.user.domain.repository.UserRepository;
 import com.example.cp_main_be.domain.member.user.dto.request.AvatarChangeRequest;
 import com.example.cp_main_be.domain.member.user.dto.response.UserRegisterResponse;
+import com.example.cp_main_be.global.exception.AvatarNotFoundException;
 import com.example.cp_main_be.global.exception.UserNotFoundException;
 import java.util.List;
 import java.util.UUID;
@@ -21,6 +24,7 @@ public class UserService {
 
   private final UserRepository userRepository;
   private final LevelService levelService;
+  private final AvatarRepository avatarRepository;
 
   public void addExperience(Long actorId, int points) {
     User user = userRepository.findById(actorId).get();
@@ -28,20 +32,20 @@ public class UserService {
     levelService.checkLevelUp(user);
   }
 
-  public void updateAvatar(Long userId, AvatarChangeRequest request) {
-    User user =
-        userRepository
-            .findById(userId)
-            .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
-    user.updateProfile(null, request.getNewAvatarUrl());
+  public void updateAvatar(User user, AvatarChangeRequest request, Long avatarId) {
+    if(user == null) return;
+    Avatar avatar = avatarRepository.findById(avatarId)
+            .orElseThrow(() -> new AvatarNotFoundException("아바타를 찾을 수 없습니다."));
+    if(avatar == null) return;
+    if(request.getNewAvatarUrl() != null)
+    {
+      Ava
+    }
     userRepository.save(user);
   }
 
-  public void updateNickname(Long userId, String newNickname) {
-    User user =
-        userRepository
-            .findById(userId)
-            .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
+  public void updateNickname(User user, String newNickname) {
+
     user.updateProfile(newNickname, null);
     userRepository.save(user);
   }

--- a/src/main/java/com/example/cp_main_be/domain/member/userblock/BlockController.java
+++ b/src/main/java/com/example/cp_main_be/domain/member/userblock/BlockController.java
@@ -1,0 +1,30 @@
+package com.example.cp_main_be.domain.member.userblock;
+
+import com.example.cp_main_be.domain.member.user.domain.User;
+import com.example.cp_main_be.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/blocks")
+@Tag(name = "사용자 차단 API")
+public class BlockController {
+  private final BlockService blockService;
+
+  @PostMapping
+  @Operation(summary = "사용자 숨기기/차단")
+  public ResponseEntity<ApiResponse<Void>> blockUser(
+      @AuthenticationPrincipal User user, @RequestBody BlockUserRequest request) {
+    blockService.blockUser(user, request.getUserIdToBlock());
+    return ResponseEntity.ok(ApiResponse.success(null));
+  }
+  // TODO: 차단 해제(DELETE) API 추가
+}

--- a/src/main/java/com/example/cp_main_be/domain/member/userblock/BlockService.java
+++ b/src/main/java/com/example/cp_main_be/domain/member/userblock/BlockService.java
@@ -1,0 +1,29 @@
+package com.example.cp_main_be.domain.member.userblock;
+
+import com.example.cp_main_be.domain.member.user.domain.User;
+import com.example.cp_main_be.domain.member.user.domain.repository.UserRepository;
+import com.example.cp_main_be.global.exception.UserNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class BlockService {
+  private final UserBlockRepository userBlockRepository;
+  private final UserRepository userRepository;
+
+  public void blockUser(User blockerUser, Long userIdToBlock) {
+    User blockedUser =
+        userRepository
+            .findById(userIdToBlock)
+            .orElseThrow(() -> new UserNotFoundException("차단할 사용자를 찾을 수 없습니다."));
+
+    // TODO: 이미 차단했는지, 자기 자신을 차단하는지 등 예외 처리
+
+    UserBlock userBlock =
+        UserBlock.builder().blockerUser(blockerUser).blockedUser(blockedUser).build();
+    userBlockRepository.save(userBlock);
+  }
+}

--- a/src/main/java/com/example/cp_main_be/domain/member/userblock/BlockUserRequest.java
+++ b/src/main/java/com/example/cp_main_be/domain/member/userblock/BlockUserRequest.java
@@ -1,0 +1,8 @@
+package com.example.cp_main_be.domain.member.userblock;
+
+import lombok.Getter;
+
+@Getter
+public class BlockUserRequest {
+  private Long userIdToBlock;
+}

--- a/src/main/java/com/example/cp_main_be/domain/member/userblock/UserBlock.java
+++ b/src/main/java/com/example/cp_main_be/domain/member/userblock/UserBlock.java
@@ -1,0 +1,41 @@
+package com.example.cp_main_be.domain.member.userblock;
+
+import com.example.cp_main_be.domain.member.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.joda.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserBlock {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "blocker_user_id", nullable = false)
+  private User blockerUser; // 차단을 한 사용자
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "blocked_user_id", nullable = false)
+  private User blockedUser; // 차단을 당한 사용자
+
+  @Column(nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @PrePersist
+  protected void onCreate() {
+    this.createdAt = LocalDateTime.now();
+  }
+
+  @Builder
+  public UserBlock(User blockerUser, User blockedUser) {
+    this.blockerUser = blockerUser;
+    this.blockedUser = blockedUser;
+  }
+}

--- a/src/main/java/com/example/cp_main_be/domain/member/userblock/UserBlockRepository.java
+++ b/src/main/java/com/example/cp_main_be/domain/member/userblock/UserBlockRepository.java
@@ -1,0 +1,13 @@
+package com.example.cp_main_be.domain.member.userblock;
+
+import com.example.cp_main_be.domain.member.user.domain.User;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface UserBlockRepository extends JpaRepository<UserBlock, Long> {
+  // 현재 사용자가 차단한 모든 사용자의 ID 목록을 조회
+  @Query("SELECT ub.blockedUser.id FROM UserBlock ub WHERE ub.blockerUser = :blocker")
+  List<Long> findBlockedUserIdsByBlocker(@Param("blocker") User blocker);
+}

--- a/src/main/java/com/example/cp_main_be/domain/mission/quiz/domain/repository/QuizRepository.java
+++ b/src/main/java/com/example/cp_main_be/domain/mission/quiz/domain/repository/QuizRepository.java
@@ -1,10 +1,16 @@
 package com.example.cp_main_be.domain.mission.quiz.domain.repository;
 
 import com.example.cp_main_be.domain.mission.quiz.domain.Quiz;
+
+import java.util.List;
 import java.util.Optional;
+
+import com.example.cp_main_be.domain.mission.quiz.enums.QuizType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface QuizRepository extends JpaRepository<Quiz, Long> {
 
   Optional<Quiz> findByDailyMissionMaster_Id(Long missionMasterId);
+
+    List<Quiz> findAllByQuizType(QuizType quizType);
 }

--- a/src/main/java/com/example/cp_main_be/domain/mission/quiz/dto/CompletedQuizResponseDTO.java
+++ b/src/main/java/com/example/cp_main_be/domain/mission/quiz/dto/CompletedQuizResponseDTO.java
@@ -12,7 +12,6 @@ public class CompletedQuizResponseDTO {
   private final QuizType quizType;
   private final Long missionId;
   private final List<CompletedQuizOptionResponseDTO> quizOptions;
-  private final Boolean isCompleted;
   private final Boolean isCorrect; // 사용자 답안 정답 여부
   private final Long selectedOptionId; // 사용자가 선택한 옵션 ID 추가
   private final Integer selectedAnswerNumber; // 사용자가 선택한 답안 번호 추가 (옵션)

--- a/src/main/java/com/example/cp_main_be/domain/mission/quiz/dto/QuizResponseDTO.java
+++ b/src/main/java/com/example/cp_main_be/domain/mission/quiz/dto/QuizResponseDTO.java
@@ -8,12 +8,10 @@ import lombok.Getter;
 @Getter
 @Builder
 public class QuizResponseDTO {
+  private final Long quizId;
   private final String quizQuestion;
   private final QuizType quizType;
-  private final Long missionId;
   private final List<QuizOptionResponseDTO> quizOptions;
-  private final Boolean isCompleted;
-
   @Getter
   @Builder
   public static class QuizOptionResponseDTO {

--- a/src/main/java/com/example/cp_main_be/domain/mission/quiz/service/QuizService.java
+++ b/src/main/java/com/example/cp_main_be/domain/mission/quiz/service/QuizService.java
@@ -8,11 +8,14 @@ import com.example.cp_main_be.domain.mission.quiz.domain.repository.QuizOptionsR
 import com.example.cp_main_be.domain.mission.quiz.domain.repository.QuizRepository;
 import com.example.cp_main_be.domain.mission.quiz.dto.CompletedQuizResponseDTO;
 import com.example.cp_main_be.domain.mission.quiz.dto.QuizResponseDTO;
+import com.example.cp_main_be.domain.mission.quiz.enums.QuizType;
 import com.example.cp_main_be.domain.mission.user_daily_mission.domain.UserDailyMission;
 import com.example.cp_main_be.domain.mission.user_daily_mission.domain.UserQuizMission;
 import com.example.cp_main_be.domain.mission.user_daily_mission.domain.repository.UserDailyMissionRepository;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import com.example.cp_main_be.global.exception.QuizNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,7 +26,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class QuizService {
 
   private final UserDailyMissionRepository userDailyMissionRepository;
-  private final DailyMissionMasterRepository dailyMissionMasterRepository;
   private final QuizRepository quizRepository;
   private final QuizOptionsRepository quizOptionsRepository;
 
@@ -49,8 +51,7 @@ public class QuizService {
         .quizType(quiz.getQuizType())
         .quizQuestion(quiz.getQuizQuestion())
         .quizOptions(optionDTOs)
-        .missionId(dailyMissionMaster.getId())
-        .isCompleted(userDailyMission.isCompleted()) // 올바른 메서드 사용
+        .quizId(quiz.getId())
         .build();
   }
 
@@ -103,12 +104,38 @@ public class QuizService {
         .quizQuestion(quiz.getQuizQuestion())
         .quizOptions(optionDTOs)
         .missionId(dailyMissionMaster.getId())
-        .isCompleted(userDailyMission.isCompleted())
         .isCorrect(isCorrect)
         .selectedOptionId(userSelectedOptionId)
         .selectedAnswerNumber(userSelectedAnswerNumber)
         .build();
   }
+
+
+  public QuizResponseDTO getQuizByType(QuizType quizType) {
+    Quiz quiz = quizRepository.findAllByQuizType(quizType).get(0);
+    if(quiz == null) throw new QuizNotFoundException("퀴즈가 존재하지 않습니다.");
+    List<QuizOptions> quizOptions = quizOptionsRepository.findAllByQuizId(quiz.getId());
+
+    // 정답 정보 제외하고 DTO 생성
+    List<QuizResponseDTO.QuizOptionResponseDTO> optionDTOs =
+            quizOptions.stream()
+                    .map(
+                            option ->
+                                    QuizResponseDTO.QuizOptionResponseDTO.builder()
+                                            .id(option.getId())
+                                            .text(option.getOptionText())
+                                            // isAnswer 필드 제거됨
+                                            .build())
+                    .collect(Collectors.toList());
+
+    return QuizResponseDTO.builder()
+            .quizType(quiz.getQuizType())
+            .quizQuestion(quiz.getQuizQuestion())
+            .quizOptions(optionDTOs)
+            .quizId(quiz.getId())
+            .build();
+  }
+
 
   // 공통 메서드들
   private UserDailyMission getUserDailyMission(Long userDailyMissionId) {

--- a/src/main/java/com/example/cp_main_be/domain/mission/user_daily_mission/presentation/UserDailyMissionController.java
+++ b/src/main/java/com/example/cp_main_be/domain/mission/user_daily_mission/presentation/UserDailyMissionController.java
@@ -5,6 +5,7 @@ import com.example.cp_main_be.domain.mission.daily_mission_master.dto.response.D
 import com.example.cp_main_be.domain.mission.quiz.dto.CompletedQuizResponseDTO;
 import com.example.cp_main_be.domain.mission.quiz.dto.QuizRequestDTO;
 import com.example.cp_main_be.domain.mission.quiz.dto.QuizResponseDTO;
+import com.example.cp_main_be.domain.mission.quiz.enums.QuizType;
 import com.example.cp_main_be.domain.mission.quiz.service.QuizService;
 import com.example.cp_main_be.domain.mission.user_daily_mission.dto.MissionPanelResponse;
 import com.example.cp_main_be.domain.mission.user_daily_mission.service.UserDailyMissionService;
@@ -56,13 +57,24 @@ public class UserDailyMissionController {
   @GetMapping("/quiz/{userDailyMissionId}")
   @Operation(summary = "퀴즈 문제 조회 API")
   public ResponseEntity<ApiResponse<QuizResponseDTO>> getQuiz(
-      @PathVariable(name = "userDailyMissionId") Long userDailyMissionId) {
+      @PathVariable(name = "userDailyMissionId") Long userDailyMissionId
+  ) {
 
     QuizResponseDTO result = quizService.getQuiz(userDailyMissionId);
     return ResponseEntity.ok(ApiResponse.success(result));
   }
 
-  // 새로운 엔드포인트 - 완료된 퀴즈 결과 조회
+  @GetMapping("/quiz/")
+  @Operation(summary = "퀴즈 타입에 맞는 퀴즈 문제 랜덤 조회 API")
+  public ResponseEntity<ApiResponse<QuizResponseDTO>> getQuizByQuizType(
+          @RequestParam QuizType quizType
+  ) {
+
+    QuizResponseDTO result = quizService.getQuizByType(quizType);
+    return ResponseEntity.ok(ApiResponse.success(result));
+  }
+
+   //새로운 엔드포인트 - 완료된 퀴즈 결과 조회
   @GetMapping("/quiz/{userDailyMissionId}/result")
   @Operation(summary = "완료된 퀴즈 결과 조회 API (정답 정보 포함)")
   public ResponseEntity<ApiResponse<CompletedQuizResponseDTO>> getQuizResult(

--- a/src/main/java/com/example/cp_main_be/domain/social/avatarpost/domain/repository/AvatarPostRepository.java
+++ b/src/main/java/com/example/cp_main_be/domain/social/avatarpost/domain/repository/AvatarPostRepository.java
@@ -13,4 +13,9 @@ public interface AvatarPostRepository extends JpaRepository<AvatarPost, Long> {
 
   @Query("SELECT ap FROM AvatarPost ap LEFT JOIN FETCH ap.comments WHERE ap.id = :postId")
   Optional<AvatarPost> findByIdWithComments(Long postId);
+
+  List<AvatarPost> findByUserInAndUser_IdNotIn(
+      List<User> users, List<Long> blockedUserIds, Pageable pageable);
+
+  List<AvatarPost> findAllByUser_IdNotIn(List<Long> blockedUserIds, Pageable pageable);
 }

--- a/src/main/java/com/example/cp_main_be/domain/social/diary/domain/Repository/DiaryRepository.java
+++ b/src/main/java/com/example/cp_main_be/domain/social/diary/domain/Repository/DiaryRepository.java
@@ -12,4 +12,9 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
   List<Diary> findByIsPublicIsTrue(Pageable pageable);
 
   List<Diary> findByUserOrderByCreatedAtDesc(User user);
+
+  List<Diary> findByUserInAndIsPublicIsTrueAndUser_IdNotIn(
+      List<User> users, List<Long> blockedUserIds, Pageable pageable);
+
+  List<Diary> findByIsPublicIsTrueAndUser_IdNotIn(List<Long> blockedUserIds, Pageable pageable);
 }

--- a/src/main/java/com/example/cp_main_be/domain/social/feed/service/FeedService.java
+++ b/src/main/java/com/example/cp_main_be/domain/social/feed/service/FeedService.java
@@ -2,6 +2,7 @@ package com.example.cp_main_be.domain.social.feed.service;
 
 import com.example.cp_main_be.domain.member.user.domain.User;
 import com.example.cp_main_be.domain.member.user.domain.repository.UserRepository;
+import com.example.cp_main_be.domain.member.userblock.UserBlockRepository;
 import com.example.cp_main_be.domain.social.avatarpost.domain.AvatarPost;
 import com.example.cp_main_be.domain.social.avatarpost.domain.repository.AvatarPostRepository;
 import com.example.cp_main_be.domain.social.avatarpost.dto.AvatarPostFeedItemResponse;
@@ -32,35 +33,38 @@ public class FeedService {
   private final DiaryRepository diaryRepository;
   private final FollowRepository followRepository;
   private final AvatarPostRepository avatarPostRepository;
+  private final UserBlockRepository userBlockRepository;
 
   public List<FeedItemResponse> getFeed(UUID currentUserUuid, String filter) {
-    // 실제로는 페이징 처리가 필요하지만, 여기서는 최신 100개씩 조회하는 것으로 가정
     Pageable pageable = PageRequest.of(0, 100, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+    User currentUser =
+        userRepository
+            .findByUuid(currentUserUuid)
+            .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
+
+    // [추가] 1. 현재 사용자가 차단한 유저 ID 목록을 먼저 조회합니다.
+    List<Long> blockedUserIds = userBlockRepository.findBlockedUserIdsByBlocker(currentUser);
 
     List<Diary> diaries;
     List<AvatarPost> avatarPosts;
 
-    // "following" 필터가 적용된 경우
     if ("following".equalsIgnoreCase(filter)) {
-      // 1. 현재 사용자 엔티티를 조회합니다.
-      User currentUser =
-          userRepository
-              .findByUuid(currentUserUuid)
-              .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
+      List<User> followingUsers =
+          followRepository.findByFollower(currentUser).stream().map(Follow::getFollowing).toList();
 
-      // 2. 현재 사용자가 팔로우하는 모든 관계를 조회합니다.
-      List<Follow> follows = followRepository.findByFollower(currentUser);
+      // [수정] 2. 차단된 유저를 제외하고 조회
+      diaries =
+          diaryRepository.findByUserInAndIsPublicIsTrueAndUser_IdNotIn(
+              followingUsers, blockedUserIds, pageable);
+      avatarPosts =
+          avatarPostRepository.findByUserInAndUser_IdNotIn(
+              followingUsers, blockedUserIds, pageable);
 
-      // 3. 팔로우 관계에서 '팔로잉 당하는' 사용자(following)들의 리스트를 추출합니다.
-      List<User> followingUsers = follows.stream().map(Follow::getFollowing).toList();
-
-      // 4. 팔로우하는 사용자들이 작성한 게시물만 조회합니다.
-      diaries = diaryRepository.findByUserInAndIsPublicIsTrue(followingUsers, pageable);
-      avatarPosts = avatarPostRepository.findByUserIn(followingUsers, pageable);
-
-    } else { // 필터가 없으면 모든 공개 게시물 조회
-      diaries = diaryRepository.findByIsPublicIsTrue(pageable);
-      avatarPosts = avatarPostRepository.findAll(pageable).getContent();
+    } else {
+      // [수정] 2. 차단된 유저를 제외하고 조회
+      diaries = diaryRepository.findByIsPublicIsTrueAndUser_IdNotIn(blockedUserIds, pageable);
+      avatarPosts = avatarPostRepository.findAllByUser_IdNotIn(blockedUserIds, pageable);
     }
 
     // 2. 각 게시물을 해당하는 DTO로 변환

--- a/src/main/java/com/example/cp_main_be/domain/social/guestbook/domain/repository/GuestbookRepository.java
+++ b/src/main/java/com/example/cp_main_be/domain/social/guestbook/domain/repository/GuestbookRepository.java
@@ -3,10 +3,14 @@ package com.example.cp_main_be.domain.social.guestbook.domain.repository;
 import com.example.cp_main_be.domain.member.user.domain.User;
 import com.example.cp_main_be.domain.social.guestbook.domain.Guestbook;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GuestbookRepository extends JpaRepository<Guestbook, Long> {
   Optional<Guestbook> findByWriterAndOwnerAndCreatedAtBetween(
       User writer, User owner, LocalDateTime startOfDay, LocalDateTime endOfDay);
+
+
+  List<Guestbook> findAllByOwner(User user);
 }

--- a/src/main/java/com/example/cp_main_be/domain/social/guestbook/domain/repository/GuestbookRepository.java
+++ b/src/main/java/com/example/cp_main_be/domain/social/guestbook/domain/repository/GuestbookRepository.java
@@ -11,6 +11,5 @@ public interface GuestbookRepository extends JpaRepository<Guestbook, Long> {
   Optional<Guestbook> findByWriterAndOwnerAndCreatedAtBetween(
       User writer, User owner, LocalDateTime startOfDay, LocalDateTime endOfDay);
 
-
   List<Guestbook> findAllByOwner(User user);
 }

--- a/src/main/java/com/example/cp_main_be/domain/social/guestbook/dto/request/GuestbookResponse.java
+++ b/src/main/java/com/example/cp_main_be/domain/social/guestbook/dto/request/GuestbookResponse.java
@@ -1,0 +1,19 @@
+package com.example.cp_main_be.domain.social.guestbook.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class GuestbookResponse {
+
+    public String author;
+    public String content;
+    public LocalDateTime createdAt;
+
+}

--- a/src/main/java/com/example/cp_main_be/domain/social/guestbook/dto/request/GuestbookResponse.java
+++ b/src/main/java/com/example/cp_main_be/domain/social/guestbook/dto/request/GuestbookResponse.java
@@ -1,9 +1,7 @@
 package com.example.cp_main_be.domain.social.guestbook.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
-import lombok.*;
-
 import java.time.LocalDateTime;
+import lombok.*;
 
 @Getter
 @Setter
@@ -12,8 +10,7 @@ import java.time.LocalDateTime;
 @Builder
 public class GuestbookResponse {
 
-    public String author;
-    public String content;
-    public LocalDateTime createdAt;
-
+  public String author;
+  public String content;
+  public LocalDateTime createdAt;
 }

--- a/src/main/java/com/example/cp_main_be/domain/social/guestbook/presentation/GuestbookController.java
+++ b/src/main/java/com/example/cp_main_be/domain/social/guestbook/presentation/GuestbookController.java
@@ -9,12 +9,11 @@ import com.example.cp_main_be.global.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -37,9 +36,9 @@ public class GuestbookController {
 
   @Operation(summary = "방명록 불러오기", description = "방명록의 글을 불러옵니다.")
   @GetMapping("/guestbook/list")
-  public ResponseEntity<ApiResponse<List<GuestbookResponse>>> getMyGuestbookList(@AuthenticationPrincipal User user) {
+  public ResponseEntity<ApiResponse<List<GuestbookResponse>>> getMyGuestbookList(
+      @AuthenticationPrincipal User user) {
     List<GuestbookResponse> guestbookResponse = guestbookService.getGuestbookList(user);
     return ResponseEntity.ok(ApiResponse.success(guestbookResponse));
   }
-
 }

--- a/src/main/java/com/example/cp_main_be/domain/social/guestbook/presentation/GuestbookController.java
+++ b/src/main/java/com/example/cp_main_be/domain/social/guestbook/presentation/GuestbookController.java
@@ -3,6 +3,7 @@ package com.example.cp_main_be.domain.social.guestbook.presentation;
 import com.example.cp_main_be.domain.member.user.domain.User;
 import com.example.cp_main_be.domain.member.user.service.UserService;
 import com.example.cp_main_be.domain.social.guestbook.dto.request.GuestbookRequest;
+import com.example.cp_main_be.domain.social.guestbook.dto.request.GuestbookResponse;
 import com.example.cp_main_be.domain.social.guestbook.service.GuestbookService;
 import com.example.cp_main_be.global.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -12,6 +13,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -31,4 +34,12 @@ public class GuestbookController {
     guestbookService.createGuestbook(writer.getId(), userId, request);
     return ResponseEntity.ok(ApiResponse.success(null));
   }
+
+  @Operation(summary = "방명록 불러오기", description = "방명록의 글을 불러옵니다.")
+  @GetMapping("/guestbook/list")
+  public ResponseEntity<ApiResponse<List<GuestbookResponse>>> getMyGuestbookList(@AuthenticationPrincipal User user) {
+    List<GuestbookResponse> guestbookResponse = guestbookService.getGuestbookList(user);
+    return ResponseEntity.ok(ApiResponse.success(guestbookResponse));
+  }
+
 }

--- a/src/main/java/com/example/cp_main_be/domain/social/guestbook/service/GuestbookService.java
+++ b/src/main/java/com/example/cp_main_be/domain/social/guestbook/service/GuestbookService.java
@@ -13,9 +13,7 @@ import com.example.cp_main_be.global.exception.UserNotFoundException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.ArrayList;
 import java.util.List;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -69,11 +67,13 @@ public class GuestbookService {
 
     // 비어있는 리스트에 stream()을 호출해도 예외가 발생하지 않고 비어있는 stream이 반환됩니다.
     return guestbookList.stream()
-            .map(guestbook -> GuestbookResponse.builder()
+        .map(
+            guestbook ->
+                GuestbookResponse.builder()
                     .author(guestbook.getWriter().getUsername())
                     .createdAt(guestbook.getCreatedAt())
                     .content(guestbook.getContent())
-                    .build()
-            ).toList();
+                    .build())
+        .toList();
   }
 }

--- a/src/main/java/com/example/cp_main_be/domain/social/guestbook/service/GuestbookService.java
+++ b/src/main/java/com/example/cp_main_be/domain/social/guestbook/service/GuestbookService.java
@@ -8,10 +8,14 @@ import com.example.cp_main_be.domain.member.user.service.UserService;
 import com.example.cp_main_be.domain.social.guestbook.domain.Guestbook;
 import com.example.cp_main_be.domain.social.guestbook.domain.repository.GuestbookRepository;
 import com.example.cp_main_be.domain.social.guestbook.dto.request.GuestbookRequest;
+import com.example.cp_main_be.domain.social.guestbook.dto.request.GuestbookResponse;
 import com.example.cp_main_be.global.exception.UserNotFoundException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -57,5 +61,19 @@ public class GuestbookService {
     if (!writerId.equals(ownerId)) {
       notificationService.send(owner, writer, NotificationType.GUESTBOOK, "/guestbooks/" + ownerId);
     }
+  }
+
+  public List<GuestbookResponse> getGuestbookList(User user) {
+
+    List<Guestbook> guestbookList = guestbookRepository.findAllByOwner(user);
+
+    // 비어있는 리스트에 stream()을 호출해도 예외가 발생하지 않고 비어있는 stream이 반환됩니다.
+    return guestbookList.stream()
+            .map(guestbook -> GuestbookResponse.builder()
+                    .author(guestbook.getWriter().getUsername())
+                    .createdAt(guestbook.getCreatedAt())
+                    .content(guestbook.getContent())
+                    .build()
+            ).toList();
   }
 }

--- a/src/main/java/com/example/cp_main_be/global/common/ApiResponse.java
+++ b/src/main/java/com/example/cp_main_be/global/common/ApiResponse.java
@@ -1,19 +1,52 @@
 package com.example.cp_main_be.global.common;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ApiResponse<T> {
 
-  private final T data;
+    @JsonProperty("isSuccess")
+    private boolean isSuccess;
 
-  private ApiResponse(T data) {
-    this.data = data;
+    @JsonProperty("code")
+    private String code;
+
+    @JsonProperty("message")
+    private String message;
+
+    @JsonProperty("result")
+    private final T result;
+
+    public static <T> ApiResponse<T> ok(T result) {
+      return onSuccess(GeneralSuccessCode.OK, result);
+    }
+
+  public static <T> ApiResponse<T> success(T result) {
+    return onSuccess(GeneralSuccessCode.OK, result);
   }
 
-  public static <T> ApiResponse<T> success(T data) {
-    return new ApiResponse<>(data);
-  }
+  public static <T> ApiResponse<T> created(T result) {
+      return onSuccess(GeneralSuccessCode.CREATED, result);
+    }
+
+    public static <T> ApiResponse<T> onSuccess(BaseSuccessCode code, T result) {
+      return new ApiResponse<>(true, code.getCode(), code.getMessage(), result);
+    }
+
+    public static <T> ApiResponse<T> onFailure(String code, String message) {
+      return onFailure(code, message, null);
+    }
+
+    public static <T> ApiResponse<T> onFailure(String code, String message, T result) {
+      return new ApiResponse<>(false, code, message, result);
+    }
+
 }

--- a/src/main/java/com/example/cp_main_be/global/common/BaseSuccessCode.java
+++ b/src/main/java/com/example/cp_main_be/global/common/BaseSuccessCode.java
@@ -1,0 +1,9 @@
+package com.example.cp_main_be.global.common;
+
+import org.springframework.http.HttpStatus;
+
+public interface BaseSuccessCode {
+    HttpStatus getHttpStatus();
+    String getCode();
+    String getMessage();
+}

--- a/src/main/java/com/example/cp_main_be/global/common/GeneralSuccessCode.java
+++ b/src/main/java/com/example/cp_main_be/global/common/GeneralSuccessCode.java
@@ -1,0 +1,17 @@
+package com.example.cp_main_be.global.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum GeneralSuccessCode implements BaseSuccessCode {
+
+    OK(HttpStatus.OK, "COMMON2000", "성공적으로 처리했습니다."),
+    CREATED(HttpStatus.CREATED, "COMMON2010", "성공적으로 생성했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/cp_main_be/global/exception/AvatarNotFoundException.java
+++ b/src/main/java/com/example/cp_main_be/global/exception/AvatarNotFoundException.java
@@ -1,7 +1,7 @@
 package com.example.cp_main_be.global.exception;
 
 public class AvatarNotFoundException extends RuntimeException {
-    public AvatarNotFoundException(String message) {
-        super(message);
-    }
+  public AvatarNotFoundException(String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/example/cp_main_be/global/exception/AvatarNotFoundException.java
+++ b/src/main/java/com/example/cp_main_be/global/exception/AvatarNotFoundException.java
@@ -1,0 +1,7 @@
+package com.example.cp_main_be.global.exception;
+
+public class AvatarNotFoundException extends RuntimeException {
+    public AvatarNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/cp_main_be/global/exception/QuizNotFoundException.java
+++ b/src/main/java/com/example/cp_main_be/global/exception/QuizNotFoundException.java
@@ -1,0 +1,7 @@
+package com.example.cp_main_be.global.exception;
+
+public class QuizNotFoundException extends RuntimeException {
+    public QuizNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/com/example/cp_main_be/domain/social/guestbook/service/GuestbookServiceTest.java
+++ b/src/test/java/com/example/cp_main_be/domain/social/guestbook/service/GuestbookServiceTest.java
@@ -1,174 +1,254 @@
-// package com.example.cp_main_be.domain.social.guestbook.service;
-//
-// import static org.assertj.core.api.Assertions.assertThat;
-// import static org.junit.jupiter.api.Assertions.assertThrows;
-// import static org.mockito.ArgumentMatchers.any;
-// import static org.mockito.BDDMockito.given;
-// import static org.mockito.Mockito.never;
-// import static org.mockito.Mockito.verify;
-//
-// import com.example.cp_main_be.domain.member.notification.domain.NotificationType;
-// import com.example.cp_main_be.domain.member.notification.service.NotificationService;
-// import com.example.cp_main_be.domain.member.user.domain.User;
-// import com.example.cp_main_be.domain.member.user.domain.repository.UserRepository;
-// import com.example.cp_main_be.domain.member.user.service.UserService;
-// import com.example.cp_main_be.domain.social.guestbook.domain.Guestbook;
-// import com.example.cp_main_be.domain.social.guestbook.domain.repository.GuestbookRepository;
-// import com.example.cp_main_be.domain.social.guestbook.dto.request.GuestbookRequest;
-// import com.example.cp_main_be.global.exception.UserNotFoundException;
-// import java.time.LocalDateTime;
-// import java.util.Optional;
-// import org.junit.jupiter.api.DisplayName;
-// import org.junit.jupiter.api.Test;
-// import org.junit.jupiter.api.extension.ExtendWith;
-// import org.mockito.ArgumentCaptor;
-// import org.mockito.InjectMocks;
-// import org.mockito.Mock;
-// import org.mockito.junit.jupiter.MockitoExtension;
-//
-// @ExtendWith(MockitoExtension.class)
-// class GuestbookServiceTest {
-//
-//  @InjectMocks private GuestbookService guestbookService;
-//
-//  @Mock private GuestbookRepository guestbookRepository;
-//
-//  @Mock private UserRepository userRepository;
-//
-//  @Mock private NotificationService notificationService;
-//
-//  @Mock private UserService userService;
-//
-//  @Test
-//  @DisplayName("방명록 작성 성공")
-//  void createGuestbook_success() {
-//    // given
-//    Long writerId = 1L;
-//    Long ownerId = 2L;
-//    GuestbookRequest request = new GuestbookRequest("안녕하세요!");
-//
-//    User writer = User.builder().id(writerId).build();
-//    User owner = User.builder().id(ownerId).build();
-//
-//    given(userRepository.findById(writerId)).willReturn(Optional.of(writer));
-//    given(userRepository.findById(ownerId)).willReturn(Optional.of(owner));
-//    given(
-//            guestbookRepository.findByWriterAndOwnerAndCreatedAtBetween(
-//                any(User.class),
-//                any(User.class),
-//                any(LocalDateTime.class),
-//                any(LocalDateTime.class)))
-//        .willReturn(Optional.empty());
-//    given(userService.getCurrentUser()).willReturn(writer);
-//
-//    // when
-//    guestbookService.createGuestbook(writerId, ownerId, request);
-//
-//    // then
-//    // 1. guestbookRepository.save가 호출되었는지 검증
-//    ArgumentCaptor<Guestbook> guestbookCaptor = ArgumentCaptor.forClass(Guestbook.class);
-//    verify(guestbookRepository).save(guestbookCaptor.capture());
-//    Guestbook savedGuestbook = guestbookCaptor.getValue();
-//    assertThat(savedGuestbook.getWriter()).isEqualTo(writer);
-//    assertThat(savedGuestbook.getOwner()).isEqualTo(owner);
-//    assertThat(savedGuestbook.getContent()).isEqualTo(request.getContent());
-//
-//    // 2. 경험치 추가 메서드가 호출되었는지 검증
-//    verify(userService).addExperience(writerId, 6);
-//
-//    // 3. 알림 전송 메서드가 호출되었는지 검증
-//    verify(notificationService)
-//        .send(owner, writer, NotificationType.GUESTBOOK, "/guestbooks/" + ownerId);
-//  }
-//
-//  @Test
-//  @DisplayName("자신에게 방명록 작성 시 알림 미전송")
-//  void createGuestbook_forSelf_doesNotSendNotification() {
-//    // given
-//    Long userId = 1L;
-//    GuestbookRequest request = new GuestbookRequest("오늘도 화이팅!");
-//
-//    User user = User.builder().id(userId).build();
-//
-//    given(userRepository.findById(userId)).willReturn(Optional.of(user));
-//    given(guestbookRepository.findByWriterAndOwnerAndCreatedAtBetween(any(), any(), any(), any()))
-//        .willReturn(Optional.empty());
-//    given(userService.getCurrentUser()).willReturn(user);
-//
-//    // when
-//    guestbookService.createGuestbook(userId, userId, request);
-//
-//    // then
-//    verify(guestbookRepository).save(any(Guestbook.class));
-//    verify(userService).addExperience(userId, 6);
-//    // 알림 서비스는 호출되지 않아야 함
-//    verify(notificationService, never()).send(any(), any(), any(), any());
-//  }
-//
-//  @Test
-//  @DisplayName("방명록 작성 실패 - 1일 1회 제한")
-//  void createGuestbook_fails_dueToDailyLimit() {
-//    // given
-//    Long writerId = 1L;
-//    Long ownerId = 2L;
-//    GuestbookRequest request = new GuestbookRequest("또 왔어요!");
-//
-//    User writer = User.builder().id(writerId).build();
-//    User owner = User.builder().id(ownerId).build();
-//
-//    given(userRepository.findById(writerId)).willReturn(Optional.of(writer));
-//    given(userRepository.findById(ownerId)).willReturn(Optional.of(owner));
-//    // 이미 오늘 작성한 기록이 있다고 가정
-//    given(guestbookRepository.findByWriterAndOwnerAndCreatedAtBetween(any(), any(), any(), any()))
-//        .willReturn(Optional.of(Guestbook.builder().build()));
-//
-//    // when & then
-//    RuntimeException exception =
-//        assertThrows(
-//            RuntimeException.class,
-//            () -> {
-//              guestbookService.createGuestbook(writerId, ownerId, request);
-//            });
-//
-//    assertThat(exception.getMessage()).isEqualTo("해당 사용자에게는 하루에 한 번만 방명록을 작성할 수 있습니다.");
-//    verify(guestbookRepository, never()).save(any()); // save는 호출되면 안 됨
-//  }
-//
-//  @Test
-//  @DisplayName("방명록 작성 실패 - 작성자를 찾을 수 없음")
-//  void createGuestbook_fails_whenWriterNotFound() {
-//    // given
-//    Long writerId = 99L; // 존재하지 않는 ID
-//    Long ownerId = 1L;
-//    GuestbookRequest request = new GuestbookRequest("안녕하세요");
-//
-//    given(userRepository.findById(writerId)).willReturn(Optional.empty());
-//
-//    // when & then
-//    assertThrows(
-//        UserNotFoundException.class,
-//        () -> {
-//          guestbookService.createGuestbook(writerId, ownerId, request);
-//        });
-//  }
-//
-//  @Test
-//  @DisplayName("방명록 작성 실패 - 소유자를 찾을 수 없음")
-//  void createGuestbook_fails_whenOwnerNotFound() {
-//    // given
-//    Long writerId = 1L;
-//    Long ownerId = 99L; // 존재하지 않는 ID
-//    GuestbookRequest request = new GuestbookRequest("안녕하세요");
-//
-//    User writer = User.builder().id(writerId).build();
-//    given(userRepository.findById(writerId)).willReturn(Optional.of(writer));
-//    given(userRepository.findById(ownerId)).willReturn(Optional.empty());
-//
-//    // when & then
-//    assertThrows(
-//        UserNotFoundException.class,
-//        () -> {
-//          guestbookService.createGuestbook(writerId, ownerId, request);
-//        });
-//  }
-// }
+package com.example.cp_main_be.domain.social.guestbook.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+import com.example.cp_main_be.domain.member.notification.domain.NotificationType;
+import com.example.cp_main_be.domain.member.notification.service.NotificationService;
+import com.example.cp_main_be.domain.member.user.domain.User;
+import com.example.cp_main_be.domain.member.user.domain.repository.UserRepository;
+import com.example.cp_main_be.domain.member.user.service.UserService;
+import com.example.cp_main_be.domain.social.guestbook.domain.Guestbook;
+import com.example.cp_main_be.domain.social.guestbook.domain.repository.GuestbookRepository;
+import com.example.cp_main_be.domain.social.guestbook.dto.request.GuestbookRequest;
+import com.example.cp_main_be.domain.social.guestbook.dto.request.GuestbookResponse;
+import com.example.cp_main_be.global.exception.UserNotFoundException;
+import java.time.LocalDateTime;
+import java.util.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GuestbookServiceTest {
+
+  @InjectMocks private GuestbookService guestbookService;
+
+  @Mock private GuestbookRepository guestbookRepository;
+
+  @Mock private UserRepository userRepository;
+
+  @Mock private NotificationService notificationService;
+
+  @Mock private UserService userService;
+
+  @Test
+  @DisplayName("방명록 작성 성공")
+  void createGuestbook_success() {
+    // given
+    Long writerId = 1L;
+    Long ownerId = 2L;
+    GuestbookRequest request = new GuestbookRequest("안녕하세요!");
+
+    User writer = User.builder().id(writerId).build();
+    User owner = User.builder().id(ownerId).build();
+
+    given(userRepository.findById(writerId)).willReturn(Optional.of(writer));
+    given(userRepository.findById(ownerId)).willReturn(Optional.of(owner));
+    given(
+            guestbookRepository.findByWriterAndOwnerAndCreatedAtBetween(
+                any(User.class),
+                any(User.class),
+                any(LocalDateTime.class),
+                any(LocalDateTime.class)))
+        .willReturn(Optional.empty());
+    given(userService.getCurrentUser()).willReturn(writer);
+
+    // when
+    guestbookService.createGuestbook(writerId, ownerId, request);
+
+    // then
+    // 1. guestbookRepository.save가 호출되었는지 검증
+    ArgumentCaptor<Guestbook> guestbookCaptor = ArgumentCaptor.forClass(Guestbook.class);
+    verify(guestbookRepository).save(guestbookCaptor.capture());
+    Guestbook savedGuestbook = guestbookCaptor.getValue();
+    assertThat(savedGuestbook.getWriter()).isEqualTo(writer);
+    assertThat(savedGuestbook.getOwner()).isEqualTo(owner);
+    assertThat(savedGuestbook.getContent()).isEqualTo(request.getContent());
+
+    // 2. 경험치 추가 메서드가 호출되었는지 검증
+    verify(userService).addExperience(writerId, 6);
+
+    // 3. 알림 전송 메서드가 호출되었는지 검증
+    verify(notificationService)
+        .send(owner, writer, NotificationType.GUESTBOOK, "/guestbooks/" + ownerId);
+  }
+
+  @Test
+  @DisplayName("자신에게 방명록 작성 시 알림 미전송")
+  void createGuestbook_forSelf_doesNotSendNotification() {
+    // given
+    Long userId = 1L;
+    GuestbookRequest request = new GuestbookRequest("오늘도 화이팅!");
+
+    User user = User.builder().id(userId).build();
+
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    given(guestbookRepository.findByWriterAndOwnerAndCreatedAtBetween(any(), any(), any(), any()))
+        .willReturn(Optional.empty());
+    given(userService.getCurrentUser()).willReturn(user);
+
+    // when
+    guestbookService.createGuestbook(userId, userId, request);
+
+    // then
+    verify(guestbookRepository).save(any(Guestbook.class));
+    verify(userService).addExperience(userId, 6);
+    // 알림 서비스는 호출되지 않아야 함
+    verify(notificationService, never()).send(any(), any(), any(), any());
+  }
+
+  @Test
+  @DisplayName("방명록 작성 실패 - 1일 1회 제한")
+  void createGuestbook_fails_dueToDailyLimit() {
+    // given
+    Long writerId = 1L;
+    Long ownerId = 2L;
+    GuestbookRequest request = new GuestbookRequest("또 왔어요!");
+
+    User writer = User.builder().id(writerId).build();
+    User owner = User.builder().id(ownerId).build();
+
+    given(userRepository.findById(writerId)).willReturn(Optional.of(writer));
+    given(userRepository.findById(ownerId)).willReturn(Optional.of(owner));
+    // 이미 오늘 작성한 기록이 있다고 가정
+    given(guestbookRepository.findByWriterAndOwnerAndCreatedAtBetween(any(), any(), any(), any()))
+        .willReturn(Optional.of(Guestbook.builder().build()));
+
+    // when & then
+    RuntimeException exception =
+        assertThrows(
+            RuntimeException.class,
+            () -> {
+              guestbookService.createGuestbook(writerId, ownerId, request);
+            });
+
+    assertThat(exception.getMessage()).isEqualTo("해당 사용자에게는 하루에 한 번만 방명록을 작성할 수 있습니다.");
+    verify(guestbookRepository, never()).save(any()); // save는 호출되면 안 됨
+  }
+
+  @Test
+  @DisplayName("방명록 작성 실패 - 작성자를 찾을 수 없음")
+  void createGuestbook_fails_whenWriterNotFound() {
+    // given
+    Long writerId = 99L; // 존재하지 않는 ID
+    Long ownerId = 1L;
+    GuestbookRequest request = new GuestbookRequest("안녕하세요");
+
+    given(userRepository.findById(writerId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThrows(
+        UserNotFoundException.class,
+        () -> {
+          guestbookService.createGuestbook(writerId, ownerId, request);
+        });
+  }
+
+  @Test
+  @DisplayName("방명록 작성 실패 - 소유자를 찾을 수 없음")
+  void createGuestbook_fails_whenOwnerNotFound() {
+    // given
+    Long writerId = 1L;
+    Long ownerId = 99L; // 존재하지 않는 ID
+    GuestbookRequest request = new GuestbookRequest("안녕하세요");
+
+    User writer = User.builder().id(writerId).build();
+    given(userRepository.findById(writerId)).willReturn(Optional.of(writer));
+    given(userRepository.findById(ownerId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThrows(
+        UserNotFoundException.class,
+        () -> {
+          guestbookService.createGuestbook(writerId, ownerId, request);
+        });
+  }
+
+  @Test
+  @DisplayName("방명록 목록 조회 성공 - 방명록이 존재할 경우")
+  void getGuestbookList_WhenGuestbooksExist_ShouldReturnResponseList() {
+    // given (주어진 상황)
+    // User 엔티티의 빌더를 사용하여 테스트용 User 객체 생성
+    User owner = User.builder()
+            .id(1L)
+            .uuid(UUID.randomUUID())
+            .username("방명록주인")
+            .email("owner@test.com")
+            .build();
+
+    User writer = User.builder()
+            .id(2L)
+            .uuid(UUID.randomUUID())
+            .username("글쓴이")
+            .email("writer@test.com")
+            .build();
+
+    // 테스트용 Guestbook 객체 생성
+    Guestbook guestbook1 = Guestbook.builder()
+            .id(101L)
+            .owner(owner)
+            .writer(writer)
+            .content("안녕하세요. 첫 번째 방명록입니다.")
+            .createdAt(LocalDateTime.now().minusDays(2))
+            .build();
+
+    Guestbook guestbook2 = Guestbook.builder()
+            .id(102L)
+            .owner(owner)
+            .writer(writer)
+            .content("두 번째 방명록입니다. 잘 보고 가요.")
+            .createdAt(LocalDateTime.now().minusDays(1))
+            .build();
+
+    List<Guestbook> mockGuestbookList = List.of(guestbook1, guestbook2);
+
+    // Repository Mocking: findAllByOwner가 호출되면 준비된 리스트를 반환하도록 설정
+    when(guestbookRepository.findAllByOwner(owner)).thenReturn(mockGuestbookList);
+
+    // when (메서드 실행)
+    List<GuestbookResponse> result = guestbookService.getGuestbookList(owner);
+
+    // then (결과 검증)
+    assertThat(result).isNotNull(); // 결과는 null이 아니어야 함
+    assertThat(result).hasSize(2);  // 결과 리스트의 크기는 2여야 함
+
+    // DTO의 내용이 엔티티의 정보와 일치하는지 검증
+    GuestbookResponse firstResponse = result.get(0);
+    assertThat(firstResponse.getAuthor()).isEqualTo(writer.getUsername()); // "글쓴이"
+    assertThat(firstResponse.getContent()).isEqualTo(guestbook1.getContent());
+    assertThat(firstResponse.getCreatedAt()).isEqualTo(guestbook1.getCreatedAt());
+
+    // repository의 특정 메소드가 정확히 1번 호출되었는지 검증
+    verify(guestbookRepository).findAllByOwner(owner);
+  }
+
+  @Test
+  @DisplayName("방명록 목록 조회 - 방명록이 존재하지 않을 경우 빈 리스트 반환")
+  void getGuestbookList_WhenNoGuestbooksExist_ShouldReturnNull() {
+    // given (주어진 상황)
+    User owner = User.builder()
+            .id(1L)
+            .username("방명록주인")
+            .build();
+
+    // Repository Mocking: findAllByOwner가 호출되면 빈 리스트를 반환하도록 설정
+    when(guestbookRepository.findAllByOwner(owner)).thenReturn(Collections.emptyList());
+
+    // when (메서드 실행)
+    List<GuestbookResponse> result = guestbookService.getGuestbookList(owner);
+
+    // then (결과 검증)
+    assertThat(result).isEqualTo(new ArrayList<>()); //
+
+    verify(guestbookRepository).findAllByOwner(owner);
+  }
+}

--- a/src/test/java/com/example/cp_main_be/domain/social/guestbook/service/GuestbookServiceTest.java
+++ b/src/test/java/com/example/cp_main_be/domain/social/guestbook/service/GuestbookServiceTest.java
@@ -18,7 +18,6 @@ import com.example.cp_main_be.domain.social.guestbook.dto.request.GuestbookRespo
 import com.example.cp_main_be.global.exception.UserNotFoundException;
 import java.time.LocalDateTime;
 import java.util.*;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -178,14 +177,16 @@ class GuestbookServiceTest {
   void getGuestbookList_WhenGuestbooksExist_ShouldReturnResponseList() {
     // given (주어진 상황)
     // User 엔티티의 빌더를 사용하여 테스트용 User 객체 생성
-    User owner = User.builder()
+    User owner =
+        User.builder()
             .id(1L)
             .uuid(UUID.randomUUID())
             .username("방명록주인")
             .email("owner@test.com")
             .build();
 
-    User writer = User.builder()
+    User writer =
+        User.builder()
             .id(2L)
             .uuid(UUID.randomUUID())
             .username("글쓴이")
@@ -193,7 +194,8 @@ class GuestbookServiceTest {
             .build();
 
     // 테스트용 Guestbook 객체 생성
-    Guestbook guestbook1 = Guestbook.builder()
+    Guestbook guestbook1 =
+        Guestbook.builder()
             .id(101L)
             .owner(owner)
             .writer(writer)
@@ -201,7 +203,8 @@ class GuestbookServiceTest {
             .createdAt(LocalDateTime.now().minusDays(2))
             .build();
 
-    Guestbook guestbook2 = Guestbook.builder()
+    Guestbook guestbook2 =
+        Guestbook.builder()
             .id(102L)
             .owner(owner)
             .writer(writer)
@@ -219,7 +222,7 @@ class GuestbookServiceTest {
 
     // then (결과 검증)
     assertThat(result).isNotNull(); // 결과는 null이 아니어야 함
-    assertThat(result).hasSize(2);  // 결과 리스트의 크기는 2여야 함
+    assertThat(result).hasSize(2); // 결과 리스트의 크기는 2여야 함
 
     // DTO의 내용이 엔티티의 정보와 일치하는지 검증
     GuestbookResponse firstResponse = result.get(0);
@@ -235,10 +238,7 @@ class GuestbookServiceTest {
   @DisplayName("방명록 목록 조회 - 방명록이 존재하지 않을 경우 빈 리스트 반환")
   void getGuestbookList_WhenNoGuestbooksExist_ShouldReturnNull() {
     // given (주어진 상황)
-    User owner = User.builder()
-            .id(1L)
-            .username("방명록주인")
-            .build();
+    User owner = User.builder().id(1L).username("방명록주인").build();
 
     // Repository Mocking: findAllByOwner가 호출되면 빈 리스트를 반환하도록 설정
     when(guestbookRepository.findAllByOwner(owner)).thenReturn(Collections.emptyList());


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 사용자 차단 API 추가 및 피드에서 차단 사용자 게시물 제외
  - 내 방명록 목록 조회 API 추가
  - 퀴즈 타입별 랜덤 조회 API 추가
  - 배송 식물 등록(멀티파트 업로드) API 추가
  - 사용자 정보 조회 API 추가
- Refactor
  - 공통 응답 포맷 표준화(isSuccess, code, message, result)
  - 아바타 변경 API 경로/파라미터 변경(/users/me/{avatarId}, 이름/URL 업데이트 지원)
  - 퀴즈 응답 스키마 변경(quizId 추가, missionId/isCompleted 제거)
  - 기존 식물 생성/수정 API 제거
- Tests
  - 방명록 서비스 테스트 추가 및 케이스 확장

<!-- end of auto-generated comment: release notes by coderabbit.ai -->