### PR TITLE
Refactor : 팔로우, 팔로잉 목록 조회 DTO 수정

### DIFF
--- a/src/main/java/com/example/cp_main_be/domain/social/follow/dto/FollowResponseDTO.java
+++ b/src/main/java/com/example/cp_main_be/domain/social/follow/dto/FollowResponseDTO.java
@@ -1,0 +1,16 @@
+package com.example.cp_main_be.domain.social.follow.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class FollowResponseDTO {
+    private Long userId;
+    private String username;
+    private String userImageUrl;
+}

--- a/src/main/java/com/example/cp_main_be/domain/social/follow/presentation/FollowController.java
+++ b/src/main/java/com/example/cp_main_be/domain/social/follow/presentation/FollowController.java
@@ -2,6 +2,7 @@ package com.example.cp_main_be.domain.social.follow.presentation;
 
 import com.example.cp_main_be.domain.member.user.domain.User;
 // UserService import 추가
+import com.example.cp_main_be.domain.social.follow.dto.FollowResponseDTO;
 import com.example.cp_main_be.domain.social.follow.service.FollowService;
 import com.example.cp_main_be.global.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -36,17 +37,17 @@ public class FollowController {
     return ResponseEntity.ok(ApiResponse.success(null));
   }
 
-  @Operation(summary = "내 팔로워 조회", description = "나를 팔로우하는 유저 목록을 조회합니다")
+  @Operation(summary = "팔로워 조회", description = "팔로우하는 유저 목록을 조회합니다")
   @GetMapping("/{userId}/followers")
-  public ResponseEntity<ApiResponse<List<User>>> getFollowers(@PathVariable Long userId) {
-    List<User> followers = followService.getFollowers(userId);
-    return ResponseEntity.ok(ApiResponse.success(followers));
+  public ResponseEntity<ApiResponse<List<FollowResponseDTO>>> getFollowers(@PathVariable Long userId) {
+    List<FollowResponseDTO> followResponseDTOS = followService.getFollowers(userId);
+    return ResponseEntity.ok(ApiResponse.success(followResponseDTOS));
   }
 
-  @Operation(summary = "내 팔로잉 조회", description = "내가 팔로우하는 유저 목록을 조회합니다")
+  @Operation(summary = "팔로잉 조회", description = "팔로우하는 유저 목록을 조회합니다")
   @GetMapping("/{userId}/following")
-  public ResponseEntity<ApiResponse<List<User>>> getFollowing(@PathVariable Long userId) {
-    List<User> following = followService.getFollowing(userId);
-    return ResponseEntity.ok(ApiResponse.success(following));
+  public ResponseEntity<ApiResponse<List<FollowResponseDTO>>> getFollowing(@PathVariable Long userId) {
+    List<FollowResponseDTO> followResponseDTOS = followService.getFollowing(userId);
+    return ResponseEntity.ok(ApiResponse.success(followResponseDTOS));
   }
 }

--- a/src/main/java/com/example/cp_main_be/domain/social/follow/service/FollowService.java
+++ b/src/main/java/com/example/cp_main_be/domain/social/follow/service/FollowService.java
@@ -6,6 +6,7 @@ import com.example.cp_main_be.domain.member.user.domain.User;
 import com.example.cp_main_be.domain.member.user.domain.repository.UserRepository;
 import com.example.cp_main_be.domain.social.follow.domain.Follow;
 import com.example.cp_main_be.domain.social.follow.domain.repository.FollowRepository;
+import com.example.cp_main_be.domain.social.follow.dto.FollowResponseDTO;
 import com.example.cp_main_be.global.exception.UserNotFoundException;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -63,24 +64,42 @@ public class FollowService {
   }
 
   @Transactional(readOnly = true)
-  public List<User> getFollowers(Long userId) {
+  public List<FollowResponseDTO> getFollowers(Long userId) {
     User user =
         userRepository
             .findById(userId)
             .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
-    return followRepository.findByFollowing(user).stream()
-        .map(Follow::getFollower)
-        .collect(Collectors.toList());
+
+    List<User> userList = followRepository.findByFollowing(user).stream()
+            .map(Follow::getFollower)
+            .toList();
+
+
+    return userList.stream()
+            .map(member -> FollowResponseDTO.builder()
+                    .username(member.getUsername())
+                    .userImageUrl(member.getProfileImageUrl())
+                    .userId(member.getId())
+                    .build())
+            .toList();
   }
 
   @Transactional(readOnly = true)
-  public List<User> getFollowing(Long userId) {
+  public List<FollowResponseDTO> getFollowing(Long userId) {
     User user =
         userRepository
             .findById(userId)
             .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
-    return followRepository.findByFollower(user).stream()
+    List<User> userList = followRepository.findByFollower(user).stream()
         .map(Follow::getFollowing)
-        .collect(Collectors.toList());
+        .toList();
+
+    return userList.stream()
+            .map(member -> FollowResponseDTO.builder()
+                    .username(member.getUsername())
+                    .userImageUrl(member.getProfileImageUrl())
+                    .userId(member.getId())
+                    .build())
+            .toList();
   }
 }


### PR DESCRIPTION
Refactor : 팔로우, 팔로잉 목록 조회 DTO 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 팔로워/팔로잉 조회 API 응답에 사용자 ID, 사용자명, 프로필 이미지 URL을 포함해 보다 간결한 사용자 정보 목록을 제공합니다.

- 문서
  - Swagger 문서의 팔로워/팔로잉 엔드포인트 명칭과 설명을 업데이트해 표현을 일관되고 명확하게 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->