### PR TITLE
refactor/get-diary-dto

### DIFF
--- a/src/main/java/com/example/cp_main_be/domain/social/diary/presentation/DiaryController.java
+++ b/src/main/java/com/example/cp_main_be/domain/social/diary/presentation/DiaryController.java
@@ -1,6 +1,7 @@
 package com.example.cp_main_be.domain.social.diary.presentation;
 
 import com.example.cp_main_be.domain.member.user.domain.User;
+import com.example.cp_main_be.domain.social.avatarpost.dto.PostInfoResponse;
 import com.example.cp_main_be.domain.social.diary.domain.Diary;
 import com.example.cp_main_be.domain.social.diary.dto.request.CreateDiaryRequest;
 import com.example.cp_main_be.domain.social.diary.dto.request.UpdateDiaryRequest;
@@ -43,10 +44,11 @@ public class DiaryController {
 
   @Operation(summary = "특정 일기 조회", description = "특정 id로 일기를 조회합니다")
   @GetMapping("/{diaryId}")
-  public ResponseEntity<ApiResponse<DiaryResponse>> getDiaryDetail(@PathVariable Long diaryId) {
-    Diary diary = diaryService.findDiaryById(diaryId);
+  public ResponseEntity<ApiResponse<PostInfoResponse>> getDiaryDetail(
+      @PathVariable Long diaryId, @AuthenticationPrincipal User user) {
+    PostInfoResponse diary = diaryService.getDiaryInfo(diaryId, user);
     // TODO: 비공개 글일 경우 작성자만 볼 수 있도록 하는 로직 추가 필요
-    return ResponseEntity.ok(ApiResponse.success(DiaryResponse.from(diary)));
+    return ResponseEntity.ok(ApiResponse.success(diary));
   }
 
   @Operation(summary = "일기 수정", description = "일기를 수정합니다")

--- a/src/main/java/com/example/cp_main_be/domain/social/diary/service/DiaryService.java
+++ b/src/main/java/com/example/cp_main_be/domain/social/diary/service/DiaryService.java
@@ -3,6 +3,7 @@ package com.example.cp_main_be.domain.social.diary.service;
 import com.example.cp_main_be.domain.avatar.image.ImageUploader;
 import com.example.cp_main_be.domain.member.user.domain.User;
 import com.example.cp_main_be.domain.member.user.domain.repository.UserRepository;
+import com.example.cp_main_be.domain.social.avatarpost.dto.PostInfoResponse;
 import com.example.cp_main_be.domain.social.diary.domain.Diary;
 import com.example.cp_main_be.domain.social.diary.domain.Repository.DiaryRepository;
 import com.example.cp_main_be.domain.social.diary.dto.request.CreateDiaryRequest;
@@ -10,6 +11,7 @@ import com.example.cp_main_be.domain.social.diary.dto.request.UpdateDiaryRequest
 import com.example.cp_main_be.domain.social.diary.dto.response.DiaryResponse;
 import com.example.cp_main_be.domain.social.diaryimage.domain.DiaryImage;
 import com.example.cp_main_be.domain.social.diaryimage.domain.DiaryImageRepository;
+import com.example.cp_main_be.domain.social.like.domain.repository.LikeRepository;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -28,6 +30,7 @@ public class DiaryService {
   private final UserRepository userRepository;
   private final ImageUploader imageUploader; // 의존성 주입은 인터페이스로
   private final DiaryImageRepository diaryImageRepository;
+  private final LikeRepository likeRepository;
 
   public Diary createDiary(User user, CreateDiaryRequest request) {
     // 1. 먼저 Diary 객체를 생성하고 저장합니다
@@ -56,12 +59,50 @@ public class DiaryService {
     return savedDiary;
   }
 
-  // 일기 상세 조회 (읽기 전용)
+  // 일기 조회 (읽기 전용)
   @Transactional(readOnly = true)
   public Diary findDiaryById(Long diaryId) {
     return diaryRepository
         .findById(diaryId)
         .orElseThrow(() -> new IllegalArgumentException("일기를 찾을 수 없습니다."));
+  }
+
+  // 일기 상세 조회 (읽기 전용)
+  @Transactional(readOnly = true)
+  public PostInfoResponse getDiaryInfo(Long diaryId, User currentUser) {
+    Diary postById =
+        diaryRepository
+            .findById(diaryId)
+            .orElseThrow(() -> new IllegalArgumentException("일기를 찾을 수 없습니다."));
+
+    // 좋아요 여부 확인
+    boolean isLiked = likeRepository.existsByUserIdAndTargetId(currentUser.getId(), diaryId);
+
+    // 응답 형식에 맞게 comment DTO 생성
+    List<PostInfoResponse.CommentResponseDTO> comments =
+        postById.getComments().stream()
+            .map(
+                comment ->
+                    PostInfoResponse.CommentResponseDTO.builder()
+                        .commentId(comment.getId())
+                        .content(comment.getContent())
+                        .profileImageUrl(comment.getWriter().getProfileImageUrl())
+                        .writer(comment.getWriter().getNickname())
+                        .build())
+            .toList();
+
+    return PostInfoResponse.builder()
+        .id(postById.getId())
+        .title(postById.getUser().getNickname())
+        .content(postById.getContent())
+        .imageUrl(postById.getDiaryImage().getImageUrl())
+        .isLiked(isLiked)
+        .isPublic(true)
+        .commentCount(comments.size())
+        .createdAt(postById.getCreatedAt())
+        .updatedAt(postById.getUpdatedAt())
+        .comment(comments)
+        .build();
   }
 
   // 내 일기 목록 조회 (읽기 전용)


### PR DESCRIPTION
다이어리 상세 조회 응답 구조 수정 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 다이어리 상세 보기 응답이 확장되어 게시글 ID, 제목, 내용, 이미지, 좋아요 여부, 공개 여부, 댓글 수, 생성/수정 시각과 함께 댓글 목록을 제공합니다. 이를 통해 사용자는 상호작용 상태를 한눈에 확인하고 댓글을 바로 열람할 수 있습니다.
- Refactor
  - 다이어리 상세 조회 엔드포인트가 인증을 요구하도록 변경되었습니다. 로그인한 사용자 기준의 좋아요 상태 등 개인화 정보가 반영되며, 비로그인 사용자는 접근할 수 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->