### PR TITLE
feat: 정원에 햇빛주기 api 시간 설정

### DIFF
--- a/src/main/java/com/example/cp_main_be/domain/garden/garden/domain/Garden.java
+++ b/src/main/java/com/example/cp_main_be/domain/garden/garden/domain/Garden.java
@@ -54,6 +54,9 @@ public class Garden {
   @Column(name = "last_watered_by_friend_at")
   private LocalDateTime lastWateredByFriendAt;
 
+  @Column(name = "last_sunlight_received_at")
+  private LocalDateTime lastSunlightReceivedAt;
+
   @CreatedDate
   @Column(updatable = false)
   private LocalDateTime createdAt;
@@ -84,6 +87,10 @@ public class Garden {
 
   public void recordFriendWateringTime() {
     this.lastWateredByFriendAt = LocalDateTime.now();
+  }
+
+  public void recordSunlightTime() {
+    this.lastSunlightReceivedAt = LocalDateTime.now();
   }
 
   public void updateBackgroundImage(GardenBackground gardenBackground) {

--- a/src/main/java/com/example/cp_main_be/domain/garden/garden/service/GardenService.java
+++ b/src/main/java/com/example/cp_main_be/domain/garden/garden/service/GardenService.java
@@ -116,8 +116,16 @@ public class GardenService {
       throw new IllegalStateException("자신의 정원에만 햇빛을 줄 수 있습니다.");
     }
 
+    // 하루에 한 번만 햇빛을 줄 수 있도록 체크 (초기화 시간: 오전 6시)
+    LocalDateTime startOfSunlightDay = getStartOfCurrentSunlightDay();
+    if (garden.getLastSunlightReceivedAt() != null
+        && garden.getLastSunlightReceivedAt().isAfter(startOfSunlightDay)) {
+      throw new IllegalStateException("오늘은 이미 햇빛을 주었습니다. 내일 오전 6시 이후에 다시 시도해주세요.");
+    }
+
     garden.increaseSunlightCount();
     userService.addExperience(actorId, SUNLIGHT_POINTS);
+    garden.recordSunlightTime(); // 햇빛 준 시간 기록
   }
 
   @Transactional
@@ -183,6 +191,24 @@ public class GardenService {
       return todayNoon.minusDays(1);
     } else {
       return todayNoon;
+    }
+  }
+
+  /**
+   * 현재 시간 기준으로 햇빛 주기 횟수가 초기화되는 시간(오전 6시)을 계산합니다. - 현재 시간이 오전 6시 이전이면, 어제 오전 6시를 반환합니다. - 현재 시간이 오전
+   * 6시 이후이면, 오늘 오전 6시를 반환합니다.
+   *
+   * @return 현재 햇빛 주기의 시작 시간
+   */
+  private LocalDateTime getStartOfCurrentSunlightDay() {
+    // 서버 위치와 관계없이 항상 한국 시간 기준으로 동작하도록 시간대를 명시합니다.
+    LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+    LocalDateTime todaySixAM = now.toLocalDate().atTime(6, 0);
+
+    if (now.isBefore(todaySixAM)) {
+      return todaySixAM.minusDays(1);
+    } else {
+      return todaySixAM;
     }
   }
 }


### PR DESCRIPTION
📝 개요
이번 PR의 핵심 내용을 한 줄로 요약해 주세요.


💻 작업 내용
이번 PR에서 작업한 내용을 상세히 설명해 주세요.

작업 내용 1
작업 내용 2
...

✅ PR 체크리스트
PR을 보내기 전에 아래 체크리스트를 확인해 주세요.

커밋 메시지는 포맷에 맞게 작성했나요?
스스로 코드를 다시 한번 검토했나요?
관련 이슈를 연결했나요?
빌드 및 테스트가 로컬에서 성공했나요?

🔗 관련 이슈
이번 PR과 관련된 이슈 번호를 기재해 주세요. 예: Closes #123


스크린샷 (선택)
UI 변경 사항이 있다면 스크린샷을 첨부해 주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 정원에 ‘햇빛 주기’가 추가되었습니다: 한국시간 기준 매일 오전 6시부터 다음날 오전 6시 사이에 1회만 가능합니다.
  * 햇빛을 주면 즉시 시간이 기록되며 해당 활동에 대한 포인트가 지급됩니다.
  * 이미 해당 날짜에 햇빛을 준 경우 재시도 시 안내 메시지가 표시됩니다.
  * 최근 햇빛 제공 시간이 상태 정보에 반영되어 활용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->