### PR TITLE
feat : 퀴즈 삭제 API 추가

### DIFF
--- a/src/main/java/com/example/cp_main_be/domain/admin/presentation/AdminController.java
+++ b/src/main/java/com/example/cp_main_be/domain/admin/presentation/AdminController.java
@@ -71,6 +71,13 @@ public class AdminController {
     return ApiResponse.ok(result);
   }
 
+  @DeleteMapping("/quiz/{quizId}")
+  @Operation(summary = "퀴즈 삭제 API")
+  public ApiResponse<Boolean> deleteQuiz(@PathVariable Long quizId) {
+    Boolean success = adminService.deleteQuiz(quizId);
+    return ApiResponse.ok(success);
+  }
+
   @PostMapping("/keywords")
   @Operation(summary = "일일 키워드 등록 API")
   public ResponseEntity<ApiResponse<DailyKeywords>> createKeyword(

--- a/src/main/java/com/example/cp_main_be/domain/admin/service/AdminService.java
+++ b/src/main/java/com/example/cp_main_be/domain/admin/service/AdminService.java
@@ -17,6 +17,7 @@ import com.example.cp_main_be.domain.mission.quiz.domain.repository.QuizReposito
 import com.example.cp_main_be.domain.reports.domain.Reports;
 import com.example.cp_main_be.domain.reports.domain.repository.ReportRepository;
 import com.example.cp_main_be.domain.reports.enums.ReportStatus;
+import com.example.cp_main_be.global.exception.QuizNotFoundException;
 import com.example.cp_main_be.global.infra.S3Uploader;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -91,6 +92,13 @@ public class AdminService {
         .build();
   }
 
+  @Transactional
+  public boolean deleteQuiz(Long quizId) {
+    Quiz quiz = quizRepository.findById(quizId)
+            .orElseThrow(() -> new QuizNotFoundException("퀴즈가 존재하지 않습니다."));
+    quizRepository.delete(quiz);
+    return true;
+  }
   // DailyMissionMasters 생성
   @Transactional
   public DailyMissionMaster createDailyMissionMasters(


### PR DESCRIPTION
feat : 퀴즈 삭제 API 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 관리자가 퀴즈를 ID로 삭제할 수 있는 기능을 추가했습니다. 성공/실패 결과가 즉시 제공되며, 삭제된 퀴즈는 목록과 상세 화면에서 더 이상 표시되지 않습니다. 잘못된 ID 요청에 대해서는 적절한 오류가 반환됩니다. 기존 퀴즈 생성 기능에는 영향이 없으며, 새 기능은 기존 관리 화면 흐름과 호환됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->