### PR TITLE
admin 설정 및 아바타 등록 플로우 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springframework.boot:spring-boot-starter-security' // Spring Security 추가
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9' // 버전을 삭제!
+	implementation 'software.amazon.awssdk:s3:2.25.43' // 최신 안정 버전 사용을 권장합니다.
 
 	implementation 'com.google.firebase:firebase-admin:9.2.0'
 	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.75' // amazonaws 사용

--- a/src/main/java/com/example/cp_main_be/domain/avatar/avatar/domain/Avatar.java
+++ b/src/main/java/com/example/cp_main_be/domain/avatar/avatar/domain/Avatar.java
@@ -27,4 +27,7 @@ public class Avatar {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "master_id", nullable = false)
   private AvatarMaster avatarMaster;
+
+  @Column(name = "image_url")
+  private String imageUrl;
 }

--- a/src/main/java/com/example/cp_main_be/domain/avatar/avatar/dto/request/CreateAvatarRequest.java
+++ b/src/main/java/com/example/cp_main_be/domain/avatar/avatar/dto/request/CreateAvatarRequest.java
@@ -5,5 +5,6 @@ import lombok.Getter;
 @Getter
 public class CreateAvatarRequest {
   private Long masterId;
+  private String imageUrl;
   private String nickname;
 }

--- a/src/main/java/com/example/cp_main_be/domain/avatar/avatar/presentation/AvatarController.java
+++ b/src/main/java/com/example/cp_main_be/domain/avatar/avatar/presentation/AvatarController.java
@@ -2,7 +2,6 @@ package com.example.cp_main_be.domain.avatar.avatar.presentation;
 
 import com.example.cp_main_be.domain.avatar.avatar.domain.AvatarMaster;
 import com.example.cp_main_be.domain.avatar.avatar.domain.repository.AvatarMasterRepository;
-import com.example.cp_main_be.domain.avatar.avatar.dto.request.CreateAvatarRequest;
 import com.example.cp_main_be.domain.avatar.avatar.dto.response.AvatarMasterResponse;
 import com.example.cp_main_be.domain.avatar.avatar.service.AvatarService;
 import com.example.cp_main_be.domain.avatar.image.service.ImageProcessingService;
@@ -39,32 +38,20 @@ public class AvatarController {
     return ResponseEntity.ok(ApiResponse.success(response));
   }
 
-  public record FallbackImageResponse(String imageUrl) {}
+  // [수정] 최종 아바타 등록을 위한 통합 DTO
+  // AI 생성 시 masterId는 null, 기존 선택 시 masterId에 해당 ID를 담아 요청
+  public record CreateAvatarFinalRequest(String nickname, String imageUrl, Long masterId) {}
 
-  @Operation(summary = "내 아바타 생성")
-  @PostMapping
-  public ResponseEntity<ApiResponse<?>> createMyAvatar(
-      @AuthenticationPrincipal User user, @RequestBody CreateAvatarRequest request) {
-    try {
-      // 2. [성공 로직] 기존과 동일하게 서비스 호출
-      avatarService.createAvatar(user.getId(), request.getMasterId(), request.getNickname());
+  @Operation(summary = "아바타 최종 등록", description = "AI로 생성했거나 기존 목록에서 선택한 아바타를 최종 등록합니다.")
+  @PostMapping // [수정] 엔드포인트를 /api/v1/avatars 로 단순화
+  public ResponseEntity<ApiResponse<Void>> createAvatar(
+      @AuthenticationPrincipal User user, @RequestBody CreateAvatarFinalRequest request) {
 
-      // 성공 시, 데이터가 없는 성공 응답 반환
-      return ResponseEntity.ok(ApiResponse.success(null));
+    // [수정] 통합된 서비스 메서드 호출
+    avatarService.createAvatar(
+        user.getId(), request.nickname(), request.imageUrl(), request.masterId());
 
-    } catch (CustomApiException e) {
-      // 3. [실패 로직] 예외를 catch하여 폴백 처리
-      log.warn("아바타 생성 실패. 기본 이미지 URL을 반환합니다. 원인: {}", e.getMessage());
-
-      // ImageProcessingService에서 랜덤 URL 가져오기
-      String fallbackImageUrl = imageProcessingService.getDefaultImageUrl();
-
-      // 가져온 URL을 응답 DTO에 담기
-      FallbackImageResponse responseDto = new FallbackImageResponse(fallbackImageUrl);
-
-      // DTO를 ApiResponse로 감싸서 성공 응답으로 반환 (HTTP 요청 자체는 성공했으므로)
-      return ResponseEntity.ok(ApiResponse.success(responseDto));
-    }
+    return ResponseEntity.ok(ApiResponse.success(null));
   }
 
   @Operation(summary = "꽃가루 주기", description = "남의 아바타에게 꽃가루를 줍니다")

--- a/src/main/java/com/example/cp_main_be/domain/avatar/avatar/presentation/AvatarController.java
+++ b/src/main/java/com/example/cp_main_be/domain/avatar/avatar/presentation/AvatarController.java
@@ -7,7 +7,6 @@ import com.example.cp_main_be.domain.avatar.avatar.service.AvatarService;
 import com.example.cp_main_be.domain.avatar.image.service.ImageProcessingService;
 import com.example.cp_main_be.domain.member.user.domain.User;
 import com.example.cp_main_be.global.common.ApiResponse;
-import com.example.cp_main_be.global.common.CustomApiException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;

--- a/src/main/java/com/example/cp_main_be/domain/avatar/avatar/service/AvatarService.java
+++ b/src/main/java/com/example/cp_main_be/domain/avatar/avatar/service/AvatarService.java
@@ -24,21 +24,37 @@ public class AvatarService {
   private final AvatarMasterRepository avatarMasterRepository; // [추가] AvatarMaster 조회 위해 주입
   private final NotificationService notificationService;
 
+  private static final Long AI_AVATAR_MASTER_ID = 9999L;
+
   // [수정] 새로운 아바타 생성 로직 구현
-  public void createAvatar(Long userId, Long masterId, String nickname) {
+  public void createAvatar(Long userId, String nickname, String imageUrl, Long masterId) {
     User user =
         userRepository
             .findById(userId)
             .orElseThrow(() -> new CustomApiException(ErrorCode.NOT_FOUND));
 
-    AvatarMaster master =
-        avatarMasterRepository
-            .findById(masterId)
-            .orElseThrow(() -> new CustomApiException(ErrorCode.NOT_FOUND));
+    AvatarMaster master;
+    if (masterId != null) {
+      // 1. 기존 목록에서 선택한 경우: 전달받은 masterId로 AvatarMaster를 찾습니다.
+      master =
+          avatarMasterRepository
+              .findById(masterId)
+              .orElseThrow(() -> new CustomApiException(ErrorCode.NOT_FOUND)); // 예외 유형 구체화
+    } else {
+      // 2. AI로 생성한 경우: 약속된 AI_AVATAR_MASTER_ID로 AvatarMaster를 찾습니다.
+      master =
+          avatarMasterRepository
+              .findById(AI_AVATAR_MASTER_ID)
+              .orElseThrow(() -> new CustomApiException(ErrorCode.NOT_FOUND));
+    }
 
-    // TODO: 사용자가 이미 해당 종류의 아바타를 가지고 있는지 확인하는 로직 추가 가능
-
-    Avatar newAvatar = Avatar.builder().user(user).avatarMaster(master).nickname(nickname).build();
+    Avatar newAvatar =
+        Avatar.builder()
+            .user(user)
+            .nickname(nickname)
+            .imageUrl(imageUrl)
+            .avatarMaster(master) // 찾은 master를 설정합니다.
+            .build();
 
     avatarRepository.save(newAvatar);
   }

--- a/src/main/java/com/example/cp_main_be/domain/avatar/image/AvatarGenerationResponse.java
+++ b/src/main/java/com/example/cp_main_be/domain/avatar/image/AvatarGenerationResponse.java
@@ -1,0 +1,12 @@
+package com.example.cp_main_be.domain.avatar.image;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class AvatarGenerationResponse {
+  String imageUrl;
+}

--- a/src/main/java/com/example/cp_main_be/domain/avatar/image/presentation/ImageController.java
+++ b/src/main/java/com/example/cp_main_be/domain/avatar/image/presentation/ImageController.java
@@ -1,5 +1,6 @@
 package com.example.cp_main_be.domain.avatar.image.presentation;
 
+import com.example.cp_main_be.domain.avatar.image.AvatarGenerationResponse;
 import com.example.cp_main_be.domain.avatar.image.service.ImageProcessingService;
 import com.example.cp_main_be.global.common.CustomApiException;
 import com.example.cp_main_be.global.common.ErrorCode;
@@ -21,7 +22,8 @@ public class ImageController {
 
   @Operation(summary = "사진 업로드, 아바타 생성", description = "업로드된 사진을 바탕으로 아바타를 png로 생성 후 반환합니다.")
   @PostMapping(value = "/register/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-  public ResponseEntity<byte[]> generateAvatar(@RequestParam("image") MultipartFile imageFile) {
+  public ResponseEntity<AvatarGenerationResponse> generateAvatar(
+      @RequestParam("image") MultipartFile imageFile) {
     // 파일 null 체크
     if (imageFile == null || imageFile.isEmpty()) {
       throw new CustomApiException(ErrorCode.INVALID_FILE);
@@ -39,9 +41,9 @@ public class ImageController {
     }
 
     // 성공 시 서비스가 byte[]를 반환. 실패 시 서비스가 예외를 던짐(아래 핸들러가 처리).
-    byte[] avatarImage = imageProcessingService.processImageWithAi(imageFile);
+    String avatarImageUrl = imageProcessingService.processImageWithAi(imageFile);
 
     // 성공 응답만 처리
-    return ResponseEntity.ok().contentType(MediaType.IMAGE_PNG).body(avatarImage);
+    return ResponseEntity.ok(new AvatarGenerationResponse(avatarImageUrl));
   }
 }

--- a/src/main/java/com/example/cp_main_be/domain/avatar/image/service/ImageProcessingService.java
+++ b/src/main/java/com/example/cp_main_be/domain/avatar/image/service/ImageProcessingService.java
@@ -2,7 +2,7 @@ package com.example.cp_main_be.domain.avatar.image.service;
 
 import com.example.cp_main_be.global.common.CustomApiException;
 import com.example.cp_main_be.global.common.ErrorCode;
-import java.net.URI;
+import com.example.cp_main_be.global.infra.StorageService;
 import java.time.Duration;
 import java.util.List;
 import java.util.Random;
@@ -25,12 +25,14 @@ public class ImageProcessingService {
   private static final Logger log = LoggerFactory.getLogger(ImageProcessingService.class);
 
   private final WebClient webClient;
+  private final StorageService storageService; // [추가] 스토리지 서비스 주입
 
   @Value("${fastapi.server.url}")
   private String fastapiServerUrl;
 
   private static final Random random = new Random();
 
+  // [기존과 동일] 실패 시 사용할 이미지 URL 목록
   private static final List<String> FALLBACK_IMAGE_URLS =
       List.of(
           "https://pub-5cb74645f3e1443686dd7aa7096913f1.r2.dev/%E1%84%86%E1%85%A9%E1%86%AB%E1%84%89%E1%85%B3%E1%84%90%E1%85%A6%E1%84%85%E1%85%A1%201.png",
@@ -43,63 +45,63 @@ public class ImageProcessingService {
           "https://pub-5cb74645f3e1443686dd7aa7096913f1.r2.dev/%E1%84%92%E1%85%A2%E1%86%BC%E1%84%8B%E1%85%AE%E1%86%AB%E1%84%86%E1%85%A9%E1%86%A8%201.png");
 
   /**
-   * 이미지를 AI 서버로 보내 아바타를 생성합니다.
+   * 이미지를 AI 서버로 보내 아바타를 생성하고, 결과 이미지의 URL을 반환합니다.
    *
    * @param imageFile 원본 이미지 파일
-   * @return 생성된 아바타 이미지 byte 배열
-   * @throws CustomApiException AI 서버 통신 실패 또는 처리 실패 시 발생
+   * @return 생성된 아바타 이미지의 최종 URL
+   * @throws CustomApiException AI 서버 통신 실패 시 발생 (실패 시 폴백 URL 반환)
    */
-  public byte[] processImageWithAi(MultipartFile imageFile) {
+  public String processImageWithAi(MultipartFile imageFile) {
     try {
-      // WebClient를 사용하여 FastAPI 서버로 이미지 파일을 POST 요청
+      // 1. WebClient를 사용하여 FastAPI 서버로부터 이미지 byte 배열을 받음
       byte[] result =
           webClient
               .post()
-              .uri(fastapiServerUrl + "/process-image") // FastAPI의 엔드포인트
+              .uri(fastapiServerUrl + "/process-image")
               .contentType(MediaType.MULTIPART_FORM_DATA)
               .body(BodyInserters.fromMultipartData("image", imageFile.getResource()))
-              .retrieve() // 응답을 받기 시작
-              // FastAPI 서버가 4xx, 5xx 에러를 반환하는 경우에 대한 처리
+              .retrieve()
               .onStatus(
-                  HttpStatusCode::isError, // HTTP 상태 코드가 에러(4xx, 5xx)인지 확인
+                  HttpStatusCode::isError,
                   clientResponse ->
                       clientResponse
-                          .bodyToMono(String.class) // 에러 응답 본문을 문자열로 읽어옴 (로깅 목적)
+                          .bodyToMono(String.class)
                           .flatMap(
                               errorBody -> {
                                 log.error(
                                     "FastAPI server error. Status: {}, Body: {}",
                                     clientResponse.statusCode(),
                                     errorBody);
-                                // 정해둔 커스텀 예외를 발생시킴
                                 return Mono.error(
                                     new CustomApiException(ErrorCode.AI_AVATAR_FAILED));
                               }))
               .bodyToMono(byte[].class)
-              .timeout(Duration.ofSeconds(30)) // 정상 응답(2xx)의 경우, 본문을 byte[]로 변환
-              .block(Duration.ofSeconds(30)); // 30초 타임아웃 설정 // 비동기 스트림의 결과를 동기적으로 기다려서 받음
+              .timeout(Duration.ofSeconds(30))
+              .block(Duration.ofSeconds(30));
+
       if (result == null || result.length == 0) {
         log.error("AI 서버에서 유효한 이미지 바이트를 받지 못했습니다 (null/empty).");
         throw new CustomApiException(ErrorCode.AI_AVATAR_FAILED);
       }
-      return result;
+
+      // 2. [변경] 성공 시, 받은 byte 배열을 스토리지에 업로드하고 URL을 받음
+      // "avatars/"는 스토리지 내 폴더 경로, 두 번째 인자는 파일 이름
+      String imageUrl =
+          storageService.uploadFile(result, "avatars/", imageFile.getOriginalFilename());
+
+      // 3. [변경] 스토리지로부터 받은 URL을 반환
+      return imageUrl;
+
     } catch (Exception e) {
+      // [변경] 실패 시, 폴백 URL 리스트에서 랜덤으로 하나를 선택하여 바로 반환
+      log.warn("AI 아바타 생성 실패. 폴백 이미지 URL을 반환합니다. 원인: {}", e.getMessage());
       String fallbackUrl = FALLBACK_IMAGE_URLS.get(random.nextInt(FALLBACK_IMAGE_URLS.size()));
-      log.info("Selected fallback image URL: {}", fallbackUrl);
-      try {
-        return webClient
-            .get()
-            .uri(URI.create(fallbackUrl))
-            .retrieve()
-            .bodyToMono(byte[].class)
-            .block();
-      } catch (Exception webClientException) {
-        log.error("R2 이미지 가져오기 실패", fallbackUrl, webClientException);
-        throw new CustomApiException(ErrorCode.AI_AVATAR_FAILED);
-      }
+      log.info("선택된 폴백 이미지 URL: {}", fallbackUrl);
+      return fallbackUrl;
     }
   }
 
+  // 이 메서드는 이제 사용되지 않지만, 다른 곳에서 사용될 수 있으므로 유지합니다.
   public String getDefaultImageUrl() {
     return FALLBACK_IMAGE_URLS.get(random.nextInt(FALLBACK_IMAGE_URLS.size()));
   }

--- a/src/main/java/com/example/cp_main_be/global/common/ErrorCode.java
+++ b/src/main/java/com/example/cp_main_be/global/common/ErrorCode.java
@@ -12,7 +12,8 @@ public enum ErrorCode {
   INVALID_FILE(HttpStatus.BAD_REQUEST, "E-50003", "적절하지 않은 파일 내용/포맷입니다."),
   INVALID_TOKEN(HttpStatus.BAD_REQUEST, "E-50004", "부적절한 토큰입니다."),
   FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "E-50005", "파일 크기 제한을 넘었습니다."),
-  NOT_FOUND(HttpStatus.NOT_FOUND, "E-50006", "Resource를 찾을 수 없습니다.");
+  NOT_FOUND(HttpStatus.NOT_FOUND, "E-50006", "Resource를 찾을 수 없습니다."),
+  UPLOAD_FAILED(HttpStatus.EXPECTATION_FAILED, "E-50007", "파일 업로드에 실패했습니다.");
 
   private final HttpStatus status;
   private final String code;

--- a/src/main/java/com/example/cp_main_be/global/config/AwsConfig.java
+++ b/src/main/java/com/example/cp_main_be/global/config/AwsConfig.java
@@ -1,44 +1,41 @@
-package com.example.cp_main_be.global.config; // AwsConfig.java
+// AwsConfig.java 또는 R2Config.java
+package com.example.cp_main_be.global.config;
 
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.client.builder.AwsClientBuilder;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import java.net.URI;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
 
 @Configuration
-public class AwsConfig {
+public class AwsConfig { // 파일 이름은 그대로 두셔도 됩니다.
 
-  // ✅ application.properties의 키 이름과 동일하게 변경
-  @Value("${cloudflare.r2.access-key}")
+  @Value("${r2.account-id}")
+  private String accountId;
+
+  @Value("${r2.access-key}")
   private String accessKey;
 
-  // ✅ application.properties의 키 이름과 동일하게 변경
-  @Value("${cloudflare.r2.secret-key}")
+  @Value("${r2.secret-key}")
   private String secretKey;
 
-  // ✅ application.properties의 키 이름과 동일하게 변경
-  @Value("${cloudflare.r2.endpoint}")
-  private String endpoint;
-
   @Bean
-  @Primary
-  public AmazonS3 amazonS3() {
-    AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+  public S3Client s3Client() {
+    // R2 접속을 위한 엔드포인트 URL 생성
+    String endpoint = String.format("https://%s.r2.cloudflarestorage.com", accountId);
 
-    // R2는 리전 개념이 약하므로 "auto"로 하드코딩하거나,
-    // properties에 cloudflare.r2.region 키를 추가한 뒤 @Value로 주입받아도 됩니다.
-    String region = "auto";
+    // R2 인증 정보 설정 (SDK v2 방식)
+    AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
+    StaticCredentialsProvider credentialsProvider = StaticCredentialsProvider.create(credentials);
 
-    return AmazonS3ClientBuilder.standard()
-        .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endpoint, region))
-        .withCredentials(new AWSStaticCredentialsProvider(credentials))
-        .withPathStyleAccessEnabled(true)
+    // S3 클라이언트 빌드 (SDK v2 방식)
+    return S3Client.builder()
+        .endpointOverride(URI.create(endpoint)) // R2 엔드포인트 지정
+        .region(Region.of("auto")) // R2는 리전이 없으므로 'auto'
+        .credentialsProvider(credentialsProvider)
         .build();
   }
 }

--- a/src/main/java/com/example/cp_main_be/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/cp_main_be/global/config/SecurityConfig.java
@@ -44,6 +44,8 @@ public class SecurityConfig {
                         "/h2-console/**",
                         "/error")
                     .permitAll() // 회원가입 및 토큰 재발급은 인증 없이 허용
+                    .requestMatchers("/api/v1/admin/**")
+                    .hasRole("ADMIN")
                     .anyRequest()
                     .authenticated() // 그 외 모든 요청은 인증 필요
             )

--- a/src/main/java/com/example/cp_main_be/global/infra/S3StorageService.java
+++ b/src/main/java/com/example/cp_main_be/global/infra/S3StorageService.java
@@ -1,0 +1,83 @@
+package com.example.cp_main_be.global.infra;
+
+import com.example.cp_main_be.global.common.CustomApiException;
+import com.example.cp_main_be.global.common.ErrorCode;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Service
+@RequiredArgsConstructor
+public class S3StorageService implements StorageService {
+
+  private final S3Client s3Client;
+
+  @Value("${cloudflare.r2.bucket}")
+  private String bucket;
+
+  @Override
+  public String uploadFile(byte[] fileBytes, String folderPath, String originalFileName) {
+    if (fileBytes == null || fileBytes.length == 0) {
+      throw new CustomApiException(ErrorCode.INVALID_FILE);
+    }
+
+    // 1. 파일의 고유한 이름 생성 (파일 충돌 방지)
+    String uniqueFileName = createUniqueFileName(originalFileName);
+    String objectKey = folderPath + uniqueFileName; // 예: "avatars/uuid-image.png"
+
+    try {
+      // 2. S3에 업로드할 요청 객체 생성
+      PutObjectRequest putObjectRequest =
+          PutObjectRequest.builder()
+              .bucket(bucket)
+              .key(objectKey)
+              .contentType(getContentType(originalFileName)) // 파일 확장자에 맞는 Content-Type 설정
+              .build();
+
+      // 3. [수정] S3 클라이언트를 통해 파일 업로드 (byte[]를 직접 사용)
+      s3Client.putObject(putObjectRequest, RequestBody.fromBytes(fileBytes));
+
+      // 4. 업로드된 파일의 URL 반환
+      return s3Client
+          .utilities()
+          .getUrl(builder -> builder.bucket(bucket).key(objectKey))
+          .toExternalForm();
+
+    } catch (Exception e) {
+      // 업로드 중 에러 발생 시
+      throw new CustomApiException(ErrorCode.UPLOAD_FAILED);
+    }
+  }
+
+  /** 원본 파일 이름에서 확장자를 추출하고, UUID를 결합하여 고유한 파일 이름을 생성합니다. */
+  private String createUniqueFileName(String originalFileName) {
+    String extension = "";
+    if (originalFileName != null && originalFileName.contains(".")) {
+      extension = originalFileName.substring(originalFileName.lastIndexOf("."));
+    }
+    return UUID.randomUUID().toString() + extension;
+  }
+
+  /** 파일 이름의 확장자를 기반으로 적절한 Content-Type을 반환합니다. */
+  private String getContentType(String fileName) {
+    if (fileName != null && fileName.contains(".")) {
+      String extension = fileName.substring(fileName.lastIndexOf(".")).toLowerCase();
+      switch (extension) {
+        case ".png":
+          return "image/png";
+        case ".jpg":
+        case ".jpeg":
+          return "image/jpeg";
+        case ".gif":
+          return "image/gif";
+        default:
+          return "application/octet-stream"; // 알 수 없는 경우 기본값
+      }
+    }
+    return "application/octet-stream";
+  }
+}

--- a/src/main/java/com/example/cp_main_be/global/infra/S3Uploader.java
+++ b/src/main/java/com/example/cp_main_be/global/infra/S3Uploader.java
@@ -1,61 +1,84 @@
 package com.example.cp_main_be.global.infra;
 
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.example.cp_main_be.domain.avatar.image.ImageUploader;
 import java.io.IOException;
+import java.net.URI;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 @Component
 @RequiredArgsConstructor
 public class S3Uploader implements ImageUploader {
 
-  private final AmazonS3 amazonS3;
+  // SDK v2 클라이언트를 주입받습니다.
+  private final S3Client s3Client;
 
+  // application.yml의 키와 일치시킵니다.
   @Value("${cloudflare.r2.bucket}")
   private String bucket;
 
   @Override
   public String upload(MultipartFile file, String path) {
-    String fileName = path + "/" + UUID.randomUUID().toString() + "_" + file.getOriginalFilename();
-    ObjectMetadata metadata = new ObjectMetadata();
-    metadata.setContentLength(file.getSize());
-    metadata.setContentType(file.getContentType());
+    String uniqueFileName = path + "/" + UUID.randomUUID() + "_" + file.getOriginalFilename();
 
     try {
-      amazonS3.putObject(bucket, fileName, file.getInputStream(), metadata);
+      // 1. 업로드 요청 객체 생성
+      PutObjectRequest putObjectRequest =
+          PutObjectRequest.builder()
+              .bucket(bucket)
+              .key(uniqueFileName)
+              .contentType(file.getContentType())
+              .build();
+
+      // 2. 파일 업로드
+      s3Client.putObject(
+          putObjectRequest, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+
+      // 3. 업로드된 파일의 URL 반환
+      return s3Client
+          .utilities()
+          .getUrl(builder -> builder.bucket(bucket).key(uniqueFileName))
+          .toExternalForm();
+
     } catch (IOException e) {
-      throw new IllegalArgumentException("파일 업로드에 실패했습니다.");
+      throw new IllegalArgumentException("파일 업로드에 실패했습니다: " + e.getMessage());
     }
-    return amazonS3.getUrl(bucket, fileName).toString();
   }
 
   @Override
   public void delete(String imageUrl) {
-    // S3 URL에서 파일 경로(key)를 추출
+    // URL에서 파일 경로(key)를 추출
     String key = extractKeyFromUrl(imageUrl);
 
     try {
-      // S3에 삭제 요청을 보냄
-      amazonS3.deleteObject(bucket, key);
+      // 1. 삭제 요청 객체 생성
+      DeleteObjectRequest deleteObjectRequest =
+          DeleteObjectRequest.builder().bucket(bucket).key(key).build();
+
+      // 2. S3에 삭제 요청
+      s3Client.deleteObject(deleteObjectRequest);
+
     } catch (Exception e) {
       throw new RuntimeException("파일 삭제에 실패했습니다: " + e.getMessage());
     }
   }
 
   private String extractKeyFromUrl(String imageUrl) {
-    // URL에서 버킷 이름과 경로를 제외한 부분 추출
-    String bucketUrl = amazonS3.getUrl(bucket, "").toString();
-    // URL 인코딩된 문자열을 처리하기 위해 replaceAll 사용
-    String key = imageUrl.replaceFirst(bucketUrl, "");
-    // 경로의 첫 번째 슬래시 제거
-    if (key.startsWith("/")) {
-      key = key.substring(1);
+    try {
+      // URI 객체를 사용하여 URL의 경로 부분을 안전하게 추출
+      URI uri = URI.create(imageUrl);
+      String path = uri.getPath();
+      // 경로의 맨 앞 '/' 문자 제거
+      return path.substring(1);
+    } catch (Exception e) {
+      throw new IllegalArgumentException("잘못된 형식의 URL입니다: " + imageUrl);
     }
-    return key;
   }
 }

--- a/src/main/java/com/example/cp_main_be/global/infra/StorageService.java
+++ b/src/main/java/com/example/cp_main_be/global/infra/StorageService.java
@@ -1,0 +1,14 @@
+package com.example.cp_main_be.global.infra;
+
+public interface StorageService {
+
+  /**
+   * 파일을 스토리지에 업로드하고 접근 URL을 반환합니다.
+   *
+   * @param fileBytes 업로드할 파일의 byte 배열
+   * @param folderPath 스토리지 내에 저장될 폴더 경로 (예: "avatars/")
+   * @param originalFileName 원본 파일 이름 (확장자 추출 및 고유 이름 생성에 사용)
+   * @return 파일에 접근할 수 있는 전체 URL
+   */
+  String uploadFile(byte[] fileBytes, String folderPath, String originalFileName);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,6 +28,7 @@ cloudflare:
     bucket: ${R2_BUCKET}
     access-key: ${R2_ACCESS_KEY}
     secret-key: ${R2_SECRET_KEY}
+    account-id: ${R2_ACCOUNT_ID}
 
 fastapi:
   server:


### PR DESCRIPTION
# Conflicts:
#	src/main/java/com/example/cp_main_be/domain/avatar/avatar/presentation/AvatarController.java #	src/main/java/com/example/cp_main_be/domain/avatar/image/service/ImageProcessingService.java

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * AI 생성 아바타를 스토리지에 업로드해 공개 URL을 제공합니다.
  * 아바타에 이미지 URL 필드가 추가되어 프로필에 이미지가 저장됩니다.
  * 생성 실패 시 기본 이미지 URL로 자동 대체됩니다.

* **API 변경**
  * 이미지 생성 API가 PNG 바이트 대신 JSON { imageUrl }을 반환합니다.
  * 아바타 생성 요청에 imageUrl이 포함되며, 응답은 본문 없는 성공으로 단순화되었습니다.

* **보안**
  * /api/v1/admin/** 엔드포인트는 ADMIN 역할이 필요합니다.

* **잡일**
  * S3 스토리지 통합 및 관련 설정·에러 코드(UPLOAD_FAILED) 추가, SDK 버전 변경 지원.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->