### PR TITLE
feat : 리얼퀴즈 개선, Pannel 정보 API 구현

### DIFF
--- a/src/main/java/com/example/cp_main_be/domain/home/HomeController.java
+++ b/src/main/java/com/example/cp_main_be/domain/home/HomeController.java
@@ -29,8 +29,7 @@ public class HomeController {
   }
 
   @GetMapping("/panel")
-  public ApiResponse<PannelResponseDTO> getPannelData(@AuthenticationPrincipal User user)
-  {
+  public ApiResponse<PannelResponseDTO> getPannelData(@AuthenticationPrincipal User user) {
     PannelResponseDTO responseDTO = homeService.getPannelData(user);
     return ApiResponse.success(responseDTO);
   }

--- a/src/main/java/com/example/cp_main_be/domain/home/HomeController.java
+++ b/src/main/java/com/example/cp_main_be/domain/home/HomeController.java
@@ -27,4 +27,11 @@ public class HomeController {
     HomeResponseDto response = homeService.getHomeScreenData(user.getId());
     return ResponseEntity.ok(ApiResponse.success(response));
   }
+
+  @GetMapping("/panel")
+  public ApiResponse<PannelResponseDTO> getPannelData(@AuthenticationPrincipal User user)
+  {
+    PannelResponseDTO responseDTO = homeService.getPannelData(user);
+    return ApiResponse.success(responseDTO);
+  }
 }

--- a/src/main/java/com/example/cp_main_be/domain/home/PannelResponseDTO.java
+++ b/src/main/java/com/example/cp_main_be/domain/home/PannelResponseDTO.java
@@ -1,0 +1,17 @@
+package com.example.cp_main_be.domain.home;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PannelResponseDTO {
+    private boolean isDairyCompleted;
+    private boolean isCheckingCompleted;
+    private boolean isQuizCompleted;
+}

--- a/src/main/java/com/example/cp_main_be/domain/home/PannelResponseDTO.java
+++ b/src/main/java/com/example/cp_main_be/domain/home/PannelResponseDTO.java
@@ -1,6 +1,5 @@
 package com.example.cp_main_be.domain.home;
 
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,7 +10,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class PannelResponseDTO {
-    private boolean isDairyCompleted;
-    private boolean isCheckingCompleted;
-    private boolean isQuizCompleted;
+  private boolean isDairyCompleted;
+  private boolean isCheckingCompleted;
+  private boolean isQuizCompleted;
 }

--- a/src/main/java/com/example/cp_main_be/domain/home/service/HomeService.java
+++ b/src/main/java/com/example/cp_main_be/domain/home/service/HomeService.java
@@ -2,11 +2,17 @@ package com.example.cp_main_be.domain.home.service;
 
 import com.example.cp_main_be.domain.garden.garden.domain.repository.GardenRepository;
 import com.example.cp_main_be.domain.home.HomeResponseDto;
+import com.example.cp_main_be.domain.home.PannelResponseDTO;
 import com.example.cp_main_be.domain.member.notification.domain.repository.NotificationRepository;
 import com.example.cp_main_be.domain.member.user.domain.User;
 import com.example.cp_main_be.domain.member.user.domain.repository.UserRepository;
+import com.example.cp_main_be.domain.mission.diary.domain.Diary;
+import com.example.cp_main_be.domain.mission.diary.domain.repository.DiaryRepository;
+import com.example.cp_main_be.domain.mission.diary.service.DiaryService;
 import com.example.cp_main_be.domain.mission.user_daily_mission.domain.UserDailyMission;
 import com.example.cp_main_be.domain.mission.user_daily_mission.domain.repository.UserDailyMissionRepository;
+import com.example.cp_main_be.domain.realquiz.UserQuiz;
+import com.example.cp_main_be.domain.realquiz.repository.UserQuizRepository;
 import com.example.cp_main_be.global.common.CustomApiException;
 import com.example.cp_main_be.global.common.ErrorCode;
 import java.time.LocalDate;
@@ -30,6 +36,9 @@ public class HomeService {
   private final GardenRepository gardenRepository;
   private final UserDailyMissionRepository userDailyMissionRepository;
   private final NotificationRepository notificationRepository;
+  private final DiaryRepository diaryRepository;
+  private final DiaryService diaryService;
+  private final UserQuizRepository userQuizRepository;
 
   // GardenService에서 가져오거나, 공통 유틸리티로 분리하면 더 좋습니다.
   private LocalDateTime getStartOfCurrentWateringDay() {
@@ -148,5 +157,27 @@ public class HomeService {
         .limit(7)
         .map(completedDates::contains)
         .collect(Collectors.toList());
+  }
+
+  public PannelResponseDTO getPannelData(User user){
+    boolean isDiaryCompleted = false;
+    boolean isQuizCompleted = false;
+    boolean isCheckingCompleted = false;
+    LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
+    LocalDateTime endOfDay = LocalDate.now().atTime(23, 59, 59);
+
+    Diary diary = diaryService.findMyDiaries(user).get(0);
+    if(diary.getCreatedAt().isAfter(LocalDate.now().atStartOfDay())){
+        isDiaryCompleted = true;
+    }
+    UserQuiz userQuiz = userQuizRepository.findAllTodayUserQuizByUser(user, startOfDay, endOfDay).get(0);
+    if(userQuiz != null && userQuiz.getIsCompleted()){ // 오늘의 퀴즈 성공시
+        isQuizCompleted = true;
+    }
+    return PannelResponseDTO.builder()
+            .isDairyCompleted(isDiaryCompleted)
+            .isQuizCompleted(isQuizCompleted)
+            .isCheckingCompleted(isCheckingCompleted)
+            .build();
   }
 }

--- a/src/main/java/com/example/cp_main_be/domain/home/service/HomeService.java
+++ b/src/main/java/com/example/cp_main_be/domain/home/service/HomeService.java
@@ -159,7 +159,7 @@ public class HomeService {
         .collect(Collectors.toList());
   }
 
-  public PannelResponseDTO getPannelData(User user){
+  public PannelResponseDTO getPannelData(User user) {
     boolean isDiaryCompleted = false;
     boolean isQuizCompleted = false;
     boolean isCheckingCompleted = false;
@@ -167,17 +167,18 @@ public class HomeService {
     LocalDateTime endOfDay = LocalDate.now().atTime(23, 59, 59);
 
     Diary diary = diaryService.findMyDiaries(user).get(0);
-    if(diary.getCreatedAt().isAfter(LocalDate.now().atStartOfDay())){
-        isDiaryCompleted = true;
+    if (diary.getCreatedAt().isAfter(LocalDate.now().atStartOfDay())) {
+      isDiaryCompleted = true;
     }
-    UserQuiz userQuiz = userQuizRepository.findAllTodayUserQuizByUser(user, startOfDay, endOfDay).get(0);
-    if(userQuiz != null && userQuiz.getIsCompleted()){ // 오늘의 퀴즈 성공시
-        isQuizCompleted = true;
+    UserQuiz userQuiz =
+        userQuizRepository.findAllTodayUserQuizByUser(user, startOfDay, endOfDay).get(0);
+    if (userQuiz != null && userQuiz.getIsCompleted()) { // 오늘의 퀴즈 성공시
+      isQuizCompleted = true;
     }
     return PannelResponseDTO.builder()
-            .isDairyCompleted(isDiaryCompleted)
-            .isQuizCompleted(isQuizCompleted)
-            .isCheckingCompleted(isCheckingCompleted)
-            .build();
+        .isDairyCompleted(isDiaryCompleted)
+        .isQuizCompleted(isQuizCompleted)
+        .isCheckingCompleted(isCheckingCompleted)
+        .build();
   }
 }

--- a/src/main/java/com/example/cp_main_be/domain/mission/quiz/enums/QuizType.java
+++ b/src/main/java/com/example/cp_main_be/domain/mission/quiz/enums/QuizType.java
@@ -2,6 +2,5 @@ package com.example.cp_main_be.domain.mission.quiz.enums;
 
 public enum QuizType {
   OX,
-  MULTI_CHOICE,
-  CHOICE_WITH_PICTURE;
+  MULTI_CHOICE
 }

--- a/src/main/java/com/example/cp_main_be/domain/mission/user_daily_mission/presentation/UserDailyMissionController.java
+++ b/src/main/java/com/example/cp_main_be/domain/mission/user_daily_mission/presentation/UserDailyMissionController.java
@@ -2,10 +2,6 @@ package com.example.cp_main_be.domain.mission.user_daily_mission.presentation;
 
 import com.example.cp_main_be.domain.member.user.domain.User;
 import com.example.cp_main_be.domain.mission.daily_mission_master.dto.response.DailyMissionResponseDTO;
-import com.example.cp_main_be.domain.mission.quiz.dto.CompletedQuizResponseDTO;
-import com.example.cp_main_be.domain.mission.quiz.dto.QuizRequestDTO;
-import com.example.cp_main_be.domain.mission.quiz.dto.QuizResponseDTO;
-import com.example.cp_main_be.domain.mission.quiz.enums.QuizType;
 import com.example.cp_main_be.domain.mission.quiz.service.QuizService;
 import com.example.cp_main_be.domain.mission.user_daily_mission.dto.MissionPanelResponse;
 import com.example.cp_main_be.domain.mission.user_daily_mission.service.UserDailyMissionService;
@@ -53,24 +49,25 @@ public class UserDailyMissionController {
     userDailyMissionService.completeDailyMission(userDailyMissionId);
     return ResponseEntity.ok(ApiResponse.success(null));
   }
-//
-//  @GetMapping("/quiz/{userDailyMissionId}")
-//  @Operation(summary = "퀴즈 문제 조회 API")
-//  public ResponseEntity<ApiResponse<QuizResponseDTO>> getQuiz(
-//      @PathVariable(name = "userDailyMissionId") Long userDailyMissionId) {
-//
-//    QuizResponseDTO result = quizService.getQuiz(userDailyMissionId);
-//    return ResponseEntity.ok(ApiResponse.success(result));
-//  }
 
-//  @GetMapping("/quiz/")
-//  @Operation(summary = "퀴즈 타입에 맞는 퀴즈 문제 랜덤 조회 API")
-//  public ResponseEntity<ApiResponse<QuizResponseDTO>> getQuizByQuizType(
-//      @RequestParam QuizType quizType) {
-//
-//    QuizResponseDTO result = quizService.getQuizByType(quizType);
-//    return ResponseEntity.ok(ApiResponse.success(result));
-//  }
+  //
+  //  @GetMapping("/quiz/{userDailyMissionId}")
+  //  @Operation(summary = "퀴즈 문제 조회 API")
+  //  public ResponseEntity<ApiResponse<QuizResponseDTO>> getQuiz(
+  //      @PathVariable(name = "userDailyMissionId") Long userDailyMissionId) {
+  //
+  //    QuizResponseDTO result = quizService.getQuiz(userDailyMissionId);
+  //    return ResponseEntity.ok(ApiResponse.success(result));
+  //  }
+
+  //  @GetMapping("/quiz/")
+  //  @Operation(summary = "퀴즈 타입에 맞는 퀴즈 문제 랜덤 조회 API")
+  //  public ResponseEntity<ApiResponse<QuizResponseDTO>> getQuizByQuizType(
+  //      @RequestParam QuizType quizType) {
+  //
+  //    QuizResponseDTO result = quizService.getQuizByType(quizType);
+  //    return ResponseEntity.ok(ApiResponse.success(result));
+  //  }
 
   //  // 새로운 엔드포인트 - 완료된 퀴즈 결과 조회
   //  @GetMapping("/quiz/{userDailyMissionId}/result")
@@ -93,12 +90,12 @@ public class UserDailyMissionController {
     return ResponseEntity.ok(ApiResponse.success(imageUrl));
   }
 
-//  @PostMapping("/quiz/{userDailyMissionId}/answer")
-//  @Operation(summary = "퀴즈 답변 제출 API")
-//  public ResponseEntity<ApiResponse<CompletedQuizResponseDTO>> summitAnswerToQuiz(
-//      @PathVariable(name = "userDailyMissionId") Long userDailyMissionId,
-//      @RequestBody QuizRequestDTO request) {
-//    CompletedQuizResponseDTO result = quizService.summitQuizAnswer(request, userDailyMissionId);
-//    return ResponseEntity.ok(ApiResponse.success(result));
-//  }
+  //  @PostMapping("/quiz/{userDailyMissionId}/answer")
+  //  @Operation(summary = "퀴즈 답변 제출 API")
+  //  public ResponseEntity<ApiResponse<CompletedQuizResponseDTO>> summitAnswerToQuiz(
+  //      @PathVariable(name = "userDailyMissionId") Long userDailyMissionId,
+  //      @RequestBody QuizRequestDTO request) {
+  //    CompletedQuizResponseDTO result = quizService.summitQuizAnswer(request, userDailyMissionId);
+  //    return ResponseEntity.ok(ApiResponse.success(result));
+  //  }
 }

--- a/src/main/java/com/example/cp_main_be/domain/mission/user_daily_mission/presentation/UserDailyMissionController.java
+++ b/src/main/java/com/example/cp_main_be/domain/mission/user_daily_mission/presentation/UserDailyMissionController.java
@@ -53,24 +53,24 @@ public class UserDailyMissionController {
     userDailyMissionService.completeDailyMission(userDailyMissionId);
     return ResponseEntity.ok(ApiResponse.success(null));
   }
+//
+//  @GetMapping("/quiz/{userDailyMissionId}")
+//  @Operation(summary = "퀴즈 문제 조회 API")
+//  public ResponseEntity<ApiResponse<QuizResponseDTO>> getQuiz(
+//      @PathVariable(name = "userDailyMissionId") Long userDailyMissionId) {
+//
+//    QuizResponseDTO result = quizService.getQuiz(userDailyMissionId);
+//    return ResponseEntity.ok(ApiResponse.success(result));
+//  }
 
-  @GetMapping("/quiz/{userDailyMissionId}")
-  @Operation(summary = "퀴즈 문제 조회 API")
-  public ResponseEntity<ApiResponse<QuizResponseDTO>> getQuiz(
-      @PathVariable(name = "userDailyMissionId") Long userDailyMissionId) {
-
-    QuizResponseDTO result = quizService.getQuiz(userDailyMissionId);
-    return ResponseEntity.ok(ApiResponse.success(result));
-  }
-
-  @GetMapping("/quiz/")
-  @Operation(summary = "퀴즈 타입에 맞는 퀴즈 문제 랜덤 조회 API")
-  public ResponseEntity<ApiResponse<QuizResponseDTO>> getQuizByQuizType(
-      @RequestParam QuizType quizType) {
-
-    QuizResponseDTO result = quizService.getQuizByType(quizType);
-    return ResponseEntity.ok(ApiResponse.success(result));
-  }
+//  @GetMapping("/quiz/")
+//  @Operation(summary = "퀴즈 타입에 맞는 퀴즈 문제 랜덤 조회 API")
+//  public ResponseEntity<ApiResponse<QuizResponseDTO>> getQuizByQuizType(
+//      @RequestParam QuizType quizType) {
+//
+//    QuizResponseDTO result = quizService.getQuizByType(quizType);
+//    return ResponseEntity.ok(ApiResponse.success(result));
+//  }
 
   //  // 새로운 엔드포인트 - 완료된 퀴즈 결과 조회
   //  @GetMapping("/quiz/{userDailyMissionId}/result")
@@ -93,12 +93,12 @@ public class UserDailyMissionController {
     return ResponseEntity.ok(ApiResponse.success(imageUrl));
   }
 
-  @PostMapping("/quiz/{userDailyMissionId}/answer")
-  @Operation(summary = "퀴즈 답변 제출 API")
-  public ResponseEntity<ApiResponse<CompletedQuizResponseDTO>> summitAnswerToQuiz(
-      @PathVariable(name = "userDailyMissionId") Long userDailyMissionId,
-      @RequestBody QuizRequestDTO request) {
-    CompletedQuizResponseDTO result = quizService.summitQuizAnswer(request, userDailyMissionId);
-    return ResponseEntity.ok(ApiResponse.success(result));
-  }
+//  @PostMapping("/quiz/{userDailyMissionId}/answer")
+//  @Operation(summary = "퀴즈 답변 제출 API")
+//  public ResponseEntity<ApiResponse<CompletedQuizResponseDTO>> summitAnswerToQuiz(
+//      @PathVariable(name = "userDailyMissionId") Long userDailyMissionId,
+//      @RequestBody QuizRequestDTO request) {
+//    CompletedQuizResponseDTO result = quizService.summitQuizAnswer(request, userDailyMissionId);
+//    return ResponseEntity.ok(ApiResponse.success(result));
+//  }
 }

--- a/src/main/java/com/example/cp_main_be/domain/mission/user_daily_mission/service/UserDailyMissionService.java
+++ b/src/main/java/com/example/cp_main_be/domain/mission/user_daily_mission/service/UserDailyMissionService.java
@@ -120,6 +120,7 @@ public class UserDailyMissionService {
                         .isCompleted(mission.isCompleted())
                         .build())
             .collect(Collectors.toList());
+
     Integer count = 0;
     for (MissionPanelResponse.DailyMissionStatusDto mission : missionDtos) {
       if (mission.isCompleted()) count++;

--- a/src/main/java/com/example/cp_main_be/domain/realquiz/RealQuiz.java
+++ b/src/main/java/com/example/cp_main_be/domain/realquiz/RealQuiz.java
@@ -32,7 +32,5 @@ public class RealQuiz {
   @Column(name = "reward_point")
   private Long rewardPoints;
 
-  @Column private Boolean isCompleted;
-
   @Column @CreationTimestamp private LocalDateTime createdAt;
 }

--- a/src/main/java/com/example/cp_main_be/domain/realquiz/UserQuiz.java
+++ b/src/main/java/com/example/cp_main_be/domain/realquiz/UserQuiz.java
@@ -2,10 +2,9 @@ package com.example.cp_main_be.domain.realquiz;
 
 import com.example.cp_main_be.domain.member.user.domain.User;
 import jakarta.persistence.*;
+import java.time.LocalDateTime;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -26,11 +25,7 @@ public class UserQuiz {
   @ManyToOne(fetch = FetchType.LAZY)
   private RealQuiz realQuiz;
 
-  @Column
-  @Builder.Default
-  private Boolean isCompleted = false;
+  @Column @Builder.Default private Boolean isCompleted = false;
 
-  @Column
-  @CreationTimestamp
-  private LocalDateTime createdAt;
+  @Column @CreationTimestamp private LocalDateTime createdAt;
 }

--- a/src/main/java/com/example/cp_main_be/domain/realquiz/UserQuiz.java
+++ b/src/main/java/com/example/cp_main_be/domain/realquiz/UserQuiz.java
@@ -3,6 +3,9 @@ package com.example.cp_main_be.domain.realquiz;
 import com.example.cp_main_be.domain.member.user.domain.User;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -22,4 +25,12 @@ public class UserQuiz {
   @JoinColumn(name = "real_quiz_id")
   @ManyToOne(fetch = FetchType.LAZY)
   private RealQuiz realQuiz;
+
+  @Column
+  @Builder.Default
+  private Boolean isCompleted = false;
+
+  @Column
+  @CreationTimestamp
+  private LocalDateTime createdAt;
 }

--- a/src/main/java/com/example/cp_main_be/domain/realquiz/presentation/RealQuizController.java
+++ b/src/main/java/com/example/cp_main_be/domain/realquiz/presentation/RealQuizController.java
@@ -52,8 +52,8 @@ public class RealQuizController {
   @PostMapping("/{quizId}/answer")
   @Operation(summary = "퀴즈 정답 제출 API")
   public ApiResponse<RealQuizAnswerResponseDTO> getRealQuizAnswer(
-      @PathVariable Long quizId, @RequestBody RealQuizAnswerRequestDTO requestDTO) {
-    RealQuizAnswerResponseDTO responseDTO = realQuizService.getRealQuizAnswer(quizId, requestDTO);
+      @PathVariable Long quizId, @RequestBody RealQuizAnswerRequestDTO requestDTO, @AuthenticationPrincipal User user) {
+    RealQuizAnswerResponseDTO responseDTO = realQuizService.getRealQuizAnswer(quizId, requestDTO, user);
     return ApiResponse.success(responseDTO);
   }
 }

--- a/src/main/java/com/example/cp_main_be/domain/realquiz/presentation/RealQuizController.java
+++ b/src/main/java/com/example/cp_main_be/domain/realquiz/presentation/RealQuizController.java
@@ -52,8 +52,11 @@ public class RealQuizController {
   @PostMapping("/{quizId}/answer")
   @Operation(summary = "퀴즈 정답 제출 API")
   public ApiResponse<RealQuizAnswerResponseDTO> getRealQuizAnswer(
-      @PathVariable Long quizId, @RequestBody RealQuizAnswerRequestDTO requestDTO, @AuthenticationPrincipal User user) {
-    RealQuizAnswerResponseDTO responseDTO = realQuizService.getRealQuizAnswer(quizId, requestDTO, user);
+      @PathVariable Long quizId,
+      @RequestBody RealQuizAnswerRequestDTO requestDTO,
+      @AuthenticationPrincipal User user) {
+    RealQuizAnswerResponseDTO responseDTO =
+        realQuizService.getRealQuizAnswer(quizId, requestDTO, user);
     return ApiResponse.success(responseDTO);
   }
 }

--- a/src/main/java/com/example/cp_main_be/domain/realquiz/repository/RealQuizRepostitory.java
+++ b/src/main/java/com/example/cp_main_be/domain/realquiz/repository/RealQuizRepostitory.java
@@ -1,10 +1,19 @@
 package com.example.cp_main_be.domain.realquiz.repository;
 
+import com.example.cp_main_be.domain.member.user.domain.User;
 import com.example.cp_main_be.domain.mission.quiz.enums.QuizType;
+import com.example.cp_main_be.domain.mission.user_daily_mission.domain.UserDailyMission;
 import com.example.cp_main_be.domain.realquiz.RealQuiz;
+
+import java.time.LocalDateTime;
 import java.util.List;
+
+import com.example.cp_main_be.domain.realquiz.UserQuiz;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RealQuizRepostitory extends JpaRepository<RealQuiz, Long> {
   List<RealQuiz> findAllByQuizType(QuizType quizType);
+
 }

--- a/src/main/java/com/example/cp_main_be/domain/realquiz/repository/RealQuizRepostitory.java
+++ b/src/main/java/com/example/cp_main_be/domain/realquiz/repository/RealQuizRepostitory.java
@@ -1,19 +1,10 @@
 package com.example.cp_main_be.domain.realquiz.repository;
 
-import com.example.cp_main_be.domain.member.user.domain.User;
 import com.example.cp_main_be.domain.mission.quiz.enums.QuizType;
-import com.example.cp_main_be.domain.mission.user_daily_mission.domain.UserDailyMission;
 import com.example.cp_main_be.domain.realquiz.RealQuiz;
-
-import java.time.LocalDateTime;
 import java.util.List;
-
-import com.example.cp_main_be.domain.realquiz.UserQuiz;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface RealQuizRepostitory extends JpaRepository<RealQuiz, Long> {
   List<RealQuiz> findAllByQuizType(QuizType quizType);
-
 }

--- a/src/main/java/com/example/cp_main_be/domain/realquiz/repository/UserQuizRepository.java
+++ b/src/main/java/com/example/cp_main_be/domain/realquiz/repository/UserQuizRepository.java
@@ -1,10 +1,27 @@
 package com.example.cp_main_be.domain.realquiz.repository;
 
 import com.example.cp_main_be.domain.member.user.domain.User;
+import com.example.cp_main_be.domain.mission.quiz.enums.QuizType;
+import com.example.cp_main_be.domain.realquiz.RealQuiz;
 import com.example.cp_main_be.domain.realquiz.UserQuiz;
+
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserQuizRepository extends JpaRepository<UserQuiz, Long> {
   Optional<UserQuiz> findByUser(User user);
+
+
+  @Query(
+          "SELECT uq FROM UserQuiz uq "
+                  + "WHERE uq.user = :user "
+                  + "AND uq.createdAt BETWEEN :startDate AND :endDate")
+  List<UserQuiz> findAllTodayUserQuizByUser(
+          @Param("user") User user,
+          @Param("startDate") LocalDateTime startDate,
+          @Param("endDate") LocalDateTime endDate);
 }

--- a/src/main/java/com/example/cp_main_be/domain/realquiz/repository/UserQuizRepository.java
+++ b/src/main/java/com/example/cp_main_be/domain/realquiz/repository/UserQuizRepository.java
@@ -1,10 +1,7 @@
 package com.example.cp_main_be.domain.realquiz.repository;
 
 import com.example.cp_main_be.domain.member.user.domain.User;
-import com.example.cp_main_be.domain.mission.quiz.enums.QuizType;
-import com.example.cp_main_be.domain.realquiz.RealQuiz;
 import com.example.cp_main_be.domain.realquiz.UserQuiz;
-
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -15,13 +12,12 @@ import org.springframework.data.repository.query.Param;
 public interface UserQuizRepository extends JpaRepository<UserQuiz, Long> {
   Optional<UserQuiz> findByUser(User user);
 
-
   @Query(
-          "SELECT uq FROM UserQuiz uq "
-                  + "WHERE uq.user = :user "
-                  + "AND uq.createdAt BETWEEN :startDate AND :endDate")
+      "SELECT uq FROM UserQuiz uq "
+          + "WHERE uq.user = :user "
+          + "AND uq.createdAt BETWEEN :startDate AND :endDate")
   List<UserQuiz> findAllTodayUserQuizByUser(
-          @Param("user") User user,
-          @Param("startDate") LocalDateTime startDate,
-          @Param("endDate") LocalDateTime endDate);
+      @Param("user") User user,
+      @Param("startDate") LocalDateTime startDate,
+      @Param("endDate") LocalDateTime endDate);
 }

--- a/src/main/java/com/example/cp_main_be/domain/realquiz/service/RealQuizService.java
+++ b/src/main/java/com/example/cp_main_be/domain/realquiz/service/RealQuizService.java
@@ -16,9 +16,14 @@ import com.example.cp_main_be.domain.realquiz.repository.RealQuizRepostitory;
 import com.example.cp_main_be.domain.realquiz.repository.UserQuizRepository;
 import com.example.cp_main_be.global.exception.QuizNotFoundException;
 import com.example.cp_main_be.global.exception.UserNotFoundException;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Random;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,7 +41,6 @@ public class RealQuizService {
     // 퀴즈 생성
     RealQuiz realQuiz =
         RealQuiz.builder()
-            .isCompleted(false)
             .quizQuestion(requestDTO.getQuizQuestion())
             .quizType(requestDTO.getQuizType())
             .answerDescription(requestDTO.getAnswerDescription())
@@ -62,7 +66,6 @@ public class RealQuizService {
     List<RealQuizResponseDTO.RealQuizOptionResponseDTO> result =
         transformToRealQuizOptionResponseDTO(realQuizOptionList);
     return RealQuizResponseDTO.builder()
-        .isCompleted(realQuiz.getIsCompleted())
         .quizId(realQuiz.getId())
         .quizQuestion(realQuiz.getQuizQuestion())
         .quizType(realQuiz.getQuizType())
@@ -83,7 +86,7 @@ public class RealQuizService {
             .findById(realQuizId)
             .orElseThrow(() -> new RuntimeException("퀴즈를 찾을 수 없습니다"));
 
-    UserQuiz userQuiz = UserQuiz.builder().realQuiz(realQuiz).user(user).build();
+    UserQuiz userQuiz = UserQuiz.builder().realQuiz(realQuiz).user(user).isCompleted(false).build();
     UserQuiz savedUserQuiz = userQuizRepository.save(userQuiz);
 
     return UserQuizCreateResponseDTO.builder()
@@ -97,7 +100,9 @@ public class RealQuizService {
 
   public RealQuizResponseDTO getRealQuiz(User user, QuizType quizType) {
 
-    UserQuiz userQuiz = userQuizRepository.findByUser(user).orElse(null);
+    LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
+    LocalDateTime endOfDay = LocalDate.now().atTime(23, 59, 59);
+    UserQuiz userQuiz = userQuizRepository.findAllTodayUserQuizByUser(user,startOfDay,endOfDay).get(0);
 
     // 퀴즈가 할당되지 않은 경우
     if (userQuiz == null) {
@@ -108,7 +113,7 @@ public class RealQuizService {
       RealQuiz realQuiz = realQuizList.get(rand);
 
       // 할당한다.
-      userQuiz = UserQuiz.builder().realQuiz(realQuiz).user(user).build();
+      userQuiz = UserQuiz.builder().realQuiz(realQuiz).user(user).isCompleted(false).build();
       userQuizRepository.save(userQuiz);
 
       return transformToRealQuizResponseDTO(realQuiz);
@@ -125,15 +130,14 @@ public class RealQuizService {
   }
 
   public RealQuizAnswerResponseDTO getRealQuizAnswer(
-      Long quizId, RealQuizAnswerRequestDTO requestDTO) {
+      Long quizId, RealQuizAnswerRequestDTO requestDTO, User user) {
     RealQuiz realQuiz =
         realQuizRepostitory
             .findById(quizId)
             .orElseThrow(() -> new QuizNotFoundException("퀴즈를 찾을 수 없습니다."));
 
-    List<RealQuizOption> realQuizOptionList = realQuizOptionRepository.findAllByRealQuiz(realQuiz);
-
-    realQuiz.setIsCompleted(true);
+    UserQuiz userQuiz = userQuizRepository.findByUser(user).orElseThrow(()->new RuntimeException("할당 된 퀴즈가 없습니다."));
+    userQuiz.setIsCompleted(true);
 
     return RealQuizAnswerResponseDTO.builder()
         .answerDescription(realQuiz.getAnswerDescription())
@@ -158,7 +162,6 @@ public class RealQuizService {
         .quizQuestion(realQuiz.getQuizQuestion())
         .answerDescription(realQuiz.getAnswerDescription())
         .quizOptions(result)
-        .isCompleted(realQuiz.getIsCompleted())
         .build();
   }
 

--- a/src/main/java/com/example/cp_main_be/domain/realquiz/service/RealQuizService.java
+++ b/src/main/java/com/example/cp_main_be/domain/realquiz/service/RealQuizService.java
@@ -16,14 +16,11 @@ import com.example.cp_main_be.domain.realquiz.repository.RealQuizRepostitory;
 import com.example.cp_main_be.domain.realquiz.repository.UserQuizRepository;
 import com.example.cp_main_be.global.exception.QuizNotFoundException;
 import com.example.cp_main_be.global.exception.UserNotFoundException;
-
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Random;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -102,7 +99,8 @@ public class RealQuizService {
 
     LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
     LocalDateTime endOfDay = LocalDate.now().atTime(23, 59, 59);
-    UserQuiz userQuiz = userQuizRepository.findAllTodayUserQuizByUser(user,startOfDay,endOfDay).get(0);
+    UserQuiz userQuiz =
+        userQuizRepository.findAllTodayUserQuizByUser(user, startOfDay, endOfDay).get(0);
 
     // 퀴즈가 할당되지 않은 경우
     if (userQuiz == null) {
@@ -136,7 +134,10 @@ public class RealQuizService {
             .findById(quizId)
             .orElseThrow(() -> new QuizNotFoundException("퀴즈를 찾을 수 없습니다."));
 
-    UserQuiz userQuiz = userQuizRepository.findByUser(user).orElseThrow(()->new RuntimeException("할당 된 퀴즈가 없습니다."));
+    UserQuiz userQuiz =
+        userQuizRepository
+            .findByUser(user)
+            .orElseThrow(() -> new RuntimeException("할당 된 퀴즈가 없습니다."));
     userQuiz.setIsCompleted(true);
 
     return RealQuizAnswerResponseDTO.builder()


### PR DESCRIPTION
## 📝 개요
> 이번 PR의 핵심 내용을 한 줄로 요약해 주세요.
- 당일 만들어진 퀴즈만 불러오도록 수정 
- 홈 화면 패널 API 구현
## 💻 작업 내용
> 이번 PR에서 작업한 내용을 상세히 설명해 주세요.
- [x] 당일 만들어진 UserQuiz 엔티티만 불러오도록 UserQuizRepository 수정
- [x] 홈 화면 패널을 위한 API 구현

<br>

## ✅ PR 체크리스트
> PR을 보내기 전에 아래 체크리스트를 확인해 주세요.
- [ ] 커밋 메시지는 포맷에 맞게 작성했나요?
- [ ] 스스로 코드를 다시 한번 검토했나요?
- [ ] 관련 이슈를 연결했나요?
- [ ] 빌드 및 테스트가 로컬에서 성공했나요?

<br>

## 🔗 관련 이슈
> 이번 PR과 관련된 이슈 번호를 기재해 주세요.
> 예: `Closes #123`

<br>

##  스크린샷 (선택)
> UI 변경 사항이 있다면 스크린샷을 첨부해 주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 홈 패널 조회 엔드포인트 추가로 일기/체크/퀴즈 완료 상태를 한눈에 확인할 수 있습니다.

- 개선
  - 일일 미션 패널에 오늘 완료한 미션 수가 실시간 계산되어 표시됩니다.
  - 퀴즈가 사용자별 ‘하루 1회’ 기준으로 관리되며, 완료 여부가 사용자 단위로 기록됩니다.

- 변경 사항
  - 퀴즈 유형이 OX와 객관식으로 단순화되었습니다.
  - 일부 일일 미션의 퀴즈 관련 조회/제출 API가 비활성화되었습니다.
  - 리얼 퀴즈 응답에서 완료 여부 표시가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->