### PR TITLE
refactor: 슬롯 확장 수정, 유저별 텃밭 조회 기능

### DIFF
--- a/src/main/java/com/example/cp_main_be/domain/garden/garden/service/GardenService.java
+++ b/src/main/java/com/example/cp_main_be/domain/garden/garden/service/GardenService.java
@@ -1,5 +1,7 @@
 package com.example.cp_main_be.domain.garden.garden.service;
 
+import com.example.cp_main_be.domain.avatar.avatar.domain.Avatar;
+import com.example.cp_main_be.domain.avatar.avatar.domain.repository.AvatarRepository;
 import com.example.cp_main_be.domain.garden.garden.domain.Garden;
 import com.example.cp_main_be.domain.garden.garden.domain.GardenBackground;
 import com.example.cp_main_be.domain.garden.garden.domain.repository.GardenBackgroundRepository;
@@ -11,6 +13,9 @@ import com.example.cp_main_be.domain.garden.wateringlog.domain.repository.Friend
 import com.example.cp_main_be.domain.member.user.domain.User;
 import com.example.cp_main_be.domain.member.user.domain.repository.UserRepository;
 import com.example.cp_main_be.domain.member.user.service.UserService;
+import com.example.cp_main_be.domain.mission.wishTree.WishTree;
+import com.example.cp_main_be.domain.mission.wishTree.WishTreeRepository;
+import com.example.cp_main_be.domain.mission.wishTree.WishTreeStage;
 import com.example.cp_main_be.global.common.CustomApiException;
 import com.example.cp_main_be.global.common.ErrorCode;
 import java.time.LocalDateTime;
@@ -39,8 +44,10 @@ public class GardenService {
   private final UserService userService;
   private final ApplicationEventPublisher eventPublisher;
   private final GardenBackgroundRepository gardenBackgroundRepository;
+  private final AvatarRepository avatarRepository;
   private final UserRepository userRepository;
   private final FriendWateringLogRepository friendWateringLogRepository;
+  private final WishTreeRepository wishTreeRepository;
 
   public GardenResponse findGardenById(Long gardenId) {
     Garden garden =
@@ -160,21 +167,45 @@ public class GardenService {
     User user =
         userRepository
             .findById(userId)
-            .orElseThrow(() -> new CustomApiException(ErrorCode.NOT_FOUND));
+            .orElseThrow(() -> new CustomApiException(ErrorCode.USER_NOT_FOUND));
 
-    int currentGardens = user.getGardens().size();
+    WishTree wishTree =
+            wishTreeRepository
+                    .findByUserId(userId)
+                    .orElseThrow(() -> new CustomApiException(ErrorCode.WISH_TREE_NOT_FOUND));
 
-    // 최대 텃밭 개수 제한은 여전히 유효하므로 여기서 검사
-    if (currentGardens >= MAX_GARDEN_COUNT) {
-      // 이미 최대치이므로 조용히 종료하거나 예외를 던질 수 있습니다.
-      // 여기서는 추가 생성을 막고 그냥 리턴합니다.
-      throw new CustomApiException(ErrorCode.GARDEN_SLOT_MAXED_OUT);
+    // 1. 사용자의 WishTree 포인트를 기준으로 현재 단계를 결정
+    // User는 WishTree를 가지고 있고, WishTree가 포인트를 관리합니다.
+    WishTreeStage currentStage = WishTreeStage.getStageForPoints(wishTree.getPoints());
+
+// 2. 현재 단계에서 가질 수 있는 최대 텃밭 개수를 가져옴
+    long maxGardensForStage = currentStage.getMaxGardens();
+
+    // 3. 사용자가 현재 보유한 텃밭 개수 확인
+    int currentGardenCount = user.getGardens().size();
+
+    // 4. 최대 텃밭 개수에 도달했는지 확인
+    if (currentGardenCount >= maxGardensForStage) {
+      // 현재 단계에서는 더 이상 텃밭을 생성할 수 없음
+      // ErrorCode에 GARDEN_SLOT_LOCKED 추가가 필요할 수 있습니다.
+      throw new CustomApiException(
+              ErrorCode.GARDEN_SLOT_LOCKED, "현재 단계에서는 더 이상 텃밭을 만들 수 없습니다. 소원나무를 성장시켜주세요.");
     }
 
-    // [기존 레벨 체크 로직 삭제!]
+    // 5. 새로 생성될 텃밭의 기본 배경과 아바타를 설정 (ID 1L을 기본값으로 가정)
+    GardenBackground defaultBackground =
+            gardenBackgroundRepository
+                    .findById(1L)
+                    .orElseThrow(
+                            () -> new CustomApiException(ErrorCode.DEFAULT_RESOURCE_NOT_FOUND, "기본 텃밭 배경을 찾을 수 없습니다."));
+    Avatar defaultAvatar =
+            avatarRepository
+                    .findById(1L)
+                    .orElseThrow(() -> new CustomApiException(ErrorCode.DEFAULT_RESOURCE_NOT_FOUND, "기본 아바타를 찾을 수 없습니다."));
 
-    // TODO: 새로 생성된 텃밭의 기본 Avatar, Background 설정 로직 필요
-    Garden newGarden = Garden.builder().user(user).slotNumber(currentGardens + 1).build();
+    // 6. 새로운 텃밭 생성
+    Garden newGarden =
+            Garden.builder().user(user).slotNumber(currentGardenCount + 1).gardenBackground(defaultBackground).avatar(defaultAvatar).build();
 
     gardenRepository.save(newGarden);
 

--- a/src/main/java/com/example/cp_main_be/domain/garden/garden/service/GardenService.java
+++ b/src/main/java/com/example/cp_main_be/domain/garden/garden/service/GardenService.java
@@ -170,15 +170,15 @@ public class GardenService {
             .orElseThrow(() -> new CustomApiException(ErrorCode.USER_NOT_FOUND));
 
     WishTree wishTree =
-            wishTreeRepository
-                    .findByUserId(userId)
-                    .orElseThrow(() -> new CustomApiException(ErrorCode.WISH_TREE_NOT_FOUND));
+        wishTreeRepository
+            .findByUserId(userId)
+            .orElseThrow(() -> new CustomApiException(ErrorCode.WISH_TREE_NOT_FOUND));
 
     // 1. 사용자의 WishTree 포인트를 기준으로 현재 단계를 결정
     // User는 WishTree를 가지고 있고, WishTree가 포인트를 관리합니다.
     WishTreeStage currentStage = WishTreeStage.getStageForPoints(wishTree.getPoints());
 
-// 2. 현재 단계에서 가질 수 있는 최대 텃밭 개수를 가져옴
+    // 2. 현재 단계에서 가질 수 있는 최대 텃밭 개수를 가져옴
     long maxGardensForStage = currentStage.getMaxGardens();
 
     // 3. 사용자가 현재 보유한 텃밭 개수 확인
@@ -189,23 +189,33 @@ public class GardenService {
       // 현재 단계에서는 더 이상 텃밭을 생성할 수 없음
       // ErrorCode에 GARDEN_SLOT_LOCKED 추가가 필요할 수 있습니다.
       throw new CustomApiException(
-              ErrorCode.GARDEN_SLOT_LOCKED, "현재 단계에서는 더 이상 텃밭을 만들 수 없습니다. 소원나무를 성장시켜주세요.");
+          ErrorCode.GARDEN_SLOT_LOCKED, "현재 단계에서는 더 이상 텃밭을 만들 수 없습니다. 소원나무를 성장시켜주세요.");
     }
 
     // 5. 새로 생성될 텃밭의 기본 배경과 아바타를 설정 (ID 1L을 기본값으로 가정)
     GardenBackground defaultBackground =
-            gardenBackgroundRepository
-                    .findById(1L)
-                    .orElseThrow(
-                            () -> new CustomApiException(ErrorCode.DEFAULT_RESOURCE_NOT_FOUND, "기본 텃밭 배경을 찾을 수 없습니다."));
+        gardenBackgroundRepository
+            .findById(1L)
+            .orElseThrow(
+                () ->
+                    new CustomApiException(
+                        ErrorCode.DEFAULT_RESOURCE_NOT_FOUND, "기본 텃밭 배경을 찾을 수 없습니다."));
     Avatar defaultAvatar =
-            avatarRepository
-                    .findById(1L)
-                    .orElseThrow(() -> new CustomApiException(ErrorCode.DEFAULT_RESOURCE_NOT_FOUND, "기본 아바타를 찾을 수 없습니다."));
+        avatarRepository
+            .findById(1L)
+            .orElseThrow(
+                () ->
+                    new CustomApiException(
+                        ErrorCode.DEFAULT_RESOURCE_NOT_FOUND, "기본 아바타를 찾을 수 없습니다."));
 
     // 6. 새로운 텃밭 생성
     Garden newGarden =
-            Garden.builder().user(user).slotNumber(currentGardenCount + 1).gardenBackground(defaultBackground).avatar(defaultAvatar).build();
+        Garden.builder()
+            .user(user)
+            .slotNumber(currentGardenCount + 1)
+            .gardenBackground(defaultBackground)
+            .avatar(defaultAvatar)
+            .build();
 
     gardenRepository.save(newGarden);
 

--- a/src/main/java/com/example/cp_main_be/domain/member/user/presentation/UserController.java
+++ b/src/main/java/com/example/cp_main_be/domain/member/user/presentation/UserController.java
@@ -1,5 +1,6 @@
 package com.example.cp_main_be.domain.member.user.presentation;
 
+import com.example.cp_main_be.domain.garden.garden.domain.Garden;
 import com.example.cp_main_be.domain.member.user.domain.User;
 import com.example.cp_main_be.domain.member.user.domain.repository.UserRepository;
 import com.example.cp_main_be.domain.member.user.dto.request.AvatarChangeRequest;
@@ -13,6 +14,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.websocket.server.PathParam;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -78,6 +82,20 @@ public class UserController {
       @AuthenticationPrincipal User user) {
     UserRegisterResponse.LevelStatusResponseDTO levelStatusResponseDTO = userService.getLevel(user);
     return ResponseEntity.ok(ApiResponse.success(levelStatusResponseDTO));
+  }
+
+  @Operation(
+      summary = "내 텃밭 ID 목록 조회",
+      description = "현재 로그인한 유저와 연결된 모든 텃밭의 ID 목록을 조회합니다. 텃밭 슬롯 번호 순으로 정렬됩니다.")
+  @GetMapping("/me/gardens")
+  public ResponseEntity<ApiResponse<List<Long>>> getMyGardenIds(@AuthenticationPrincipal User user) {
+    List<Long> gardenIds =
+        user.getGardens().stream()
+            .sorted(Comparator.comparing(Garden::getSlotNumber))
+            .map(Garden::getId)
+            .collect(Collectors.toList());
+
+    return ResponseEntity.ok(ApiResponse.success(gardenIds));
   }
 
   @Operation(summary = "유저 정보 조회", description = "유저 정보를 조회합니다")

--- a/src/main/java/com/example/cp_main_be/domain/member/user/presentation/UserController.java
+++ b/src/main/java/com/example/cp_main_be/domain/member/user/presentation/UserController.java
@@ -88,7 +88,8 @@ public class UserController {
       summary = "내 텃밭 ID 목록 조회",
       description = "현재 로그인한 유저와 연결된 모든 텃밭의 ID 목록을 조회합니다. 텃밭 슬롯 번호 순으로 정렬됩니다.")
   @GetMapping("/me/gardens")
-  public ResponseEntity<ApiResponse<List<Long>>> getMyGardenIds(@AuthenticationPrincipal User user) {
+  public ResponseEntity<ApiResponse<List<Long>>> getMyGardenIds(
+      @AuthenticationPrincipal User user) {
     List<Long> gardenIds =
         user.getGardens().stream()
             .sorted(Comparator.comparing(Garden::getSlotNumber))

--- a/src/main/java/com/example/cp_main_be/global/common/ErrorCode.java
+++ b/src/main/java/com/example/cp_main_be/global/common/ErrorCode.java
@@ -15,7 +15,8 @@ public enum ErrorCode {
       HttpStatus.BAD_REQUEST, "E40003", "오늘은 다른 사람의 정원에 더 이상 물을 줄 수 없습니다."),
   ALREADY_WATERED_GARDEN(HttpStatus.BAD_REQUEST, "E40004", "이 정원에는 오늘 이미 물을 주었습니다."),
   SUNLIGHT_COOL_DOWN(HttpStatus.BAD_REQUEST, "E40005", "오늘은 이미 햇빛을 주었습니다."),
-  GARDEN_SLOT_MAXED_OUT(HttpStatus.BAD_REQUEST, "E40006", "더 이상 텃밭을 추가할 수 없습니다."), // 최종 3개 도달 시 사용 가능
+  GARDEN_SLOT_MAXED_OUT(
+      HttpStatus.BAD_REQUEST, "E40006", "더 이상 텃밭을 추가할 수 없습니다."), // 최종 3개 도달 시 사용 가능
   INVALID_FILE(HttpStatus.BAD_REQUEST, "E40007", "적절하지 않은 파일 내용/포맷입니다."),
   GARDEN_SLOT_LOCKED(
       HttpStatus.BAD_REQUEST, "E40008", "현재 단계에서는 더 이상 텃밭을 만들 수 없습니다. 소원나무를 성장시켜주세요."),

--- a/src/main/java/com/example/cp_main_be/global/common/ErrorCode.java
+++ b/src/main/java/com/example/cp_main_be/global/common/ErrorCode.java
@@ -15,12 +15,14 @@ public enum ErrorCode {
       HttpStatus.BAD_REQUEST, "E40003", "오늘은 다른 사람의 정원에 더 이상 물을 줄 수 없습니다."),
   ALREADY_WATERED_GARDEN(HttpStatus.BAD_REQUEST, "E40004", "이 정원에는 오늘 이미 물을 주었습니다."),
   SUNLIGHT_COOL_DOWN(HttpStatus.BAD_REQUEST, "E40005", "오늘은 이미 햇빛을 주었습니다."),
-  GARDEN_SLOT_MAXED_OUT(HttpStatus.BAD_REQUEST, "E40006", "더 이상 텃밭을 추가할 수 없습니다."),
+  GARDEN_SLOT_MAXED_OUT(HttpStatus.BAD_REQUEST, "E40006", "더 이상 텃밭을 추가할 수 없습니다."), // 최종 3개 도달 시 사용 가능
   INVALID_FILE(HttpStatus.BAD_REQUEST, "E40007", "적절하지 않은 파일 내용/포맷입니다."),
-  FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "E40008", "파일 크기 제한을 넘었습니다."),
+  GARDEN_SLOT_LOCKED(
+      HttpStatus.BAD_REQUEST, "E40008", "현재 단계에서는 더 이상 텃밭을 만들 수 없습니다. 소원나무를 성장시켜주세요."),
+  FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "E40009", "파일 크기 제한을 넘었습니다."),
   INVALID_MISSION_TYPE_FOR_QUIZ_OPTION(
-      HttpStatus.BAD_REQUEST, "E40009", "퀴즈 타입의 미션에만 선지를 추가할 수 있습니다."),
-  INVALID_REQUEST(HttpStatus.BAD_REQUEST, "E40010", "잘못된 요청입니다."),
+      HttpStatus.BAD_REQUEST, "E40010", "퀴즈 타입의 미션에만 선지를 추가할 수 있습니다."),
+  INVALID_REQUEST(HttpStatus.BAD_REQUEST, "E40011", "잘못된 요청입니다."),
 
   // 403 Forbidden
   ACCESS_DENIED(HttpStatus.FORBIDDEN, "E40301", "요청에 대한 권한이 없습니다."),
@@ -35,6 +37,8 @@ public enum ErrorCode {
   QUIZ_NOT_FOUND(HttpStatus.NOT_FOUND, "E40406", "해당 퀴즈를 찾을 수 없습니다."),
   REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "E40407", "해당 신고를 찾을 수 없습니다."),
   AVATAR_MASTER_NOT_FOUND(HttpStatus.NOT_FOUND, "E40408", "해당 아바타 원본을 찾을 수 없습니다."),
+  WISH_TREE_NOT_FOUND(HttpStatus.NOT_FOUND, "E40409", "소원나무 정보를 찾을 수 없습니다."),
+  DEFAULT_RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "E40410", "필수 기본 리소스를 찾을 수 없습니다."),
 
   // 417 Expectation Failed
   UPLOAD_FAILED(HttpStatus.EXPECTATION_FAILED, "E41701", "파일 업로드에 실패했습니다."),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -55,7 +55,7 @@ spring:
     password:
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     defer-datasource-initialization: true
   h2:
     console:


### PR DESCRIPTION
📝 개요
이번 PR의 핵심 내용을 한 줄로 요약해 주세요.


💻 작업 내용
이번 PR에서 작업한 내용을 상세히 설명해 주세요.

작업 내용 1
작업 내용 2
...

✅ PR 체크리스트
PR을 보내기 전에 아래 체크리스트를 확인해 주세요.

커밋 메시지는 포맷에 맞게 작성했나요?
스스로 코드를 다시 한번 검토했나요?
관련 이슈를 연결했나요?
빌드 및 테스트가 로컬에서 성공했나요?

🔗 관련 이슈
이번 PR과 관련된 이슈 번호를 기재해 주세요. 예: Closes #131 


스크린샷 (선택)
UI 변경 사항이 있다면 스크린샷을 첨부해 주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 단계 기반 텃밭 슬롯 해제: 현재 단계에서 허용된 최대 개수를 초과하면 안내 메시지로 생성 제한을 알립니다.
  - 새 텃밭 생성 시 기본 배경/아바타가 자동 적용됩니다.
  - 내 텃밭 ID 목록 조회 API 추가: 현재 사용자 기준으로 슬롯 순서대로 정렬된 ID 리스트를 반환합니다.
  - 오류 코드/메시지 확장: 텃밭 슬롯 잠김, 소원나무 미존재, 기본 리소스 미존재 상황을 명확히 안내합니다.
- Chores
  - 로컬 환경 DB 스키마 전략을 create-drop에서 update로 변경.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->