### PR TITLE
refactor/물주기 햇빛주기 에러 수정

### DIFF
--- a/src/main/java/com/example/cp_main_be/domain/garden/garden/service/GardenService.java
+++ b/src/main/java/com/example/cp_main_be/domain/garden/garden/service/GardenService.java
@@ -159,7 +159,8 @@ public class GardenService {
     LocalDateTime startOfSunlightDay = getStartOfCurrentSunlightDay();
     if (garden.getLastSunlightReceivedAt() != null
         && garden.getLastSunlightReceivedAt().isAfter(startOfSunlightDay)) {
-      throw new CustomApiException(ErrorCode.SUNLIGHT_COOL_DOWN,"이미 햇빛을 주었습니다. 내일 오전 6시 이후에 다시 시도해주세요.");
+      throw new CustomApiException(
+          ErrorCode.SUNLIGHT_COOL_DOWN, "이미 햇빛을 주었습니다. 내일 오전 6시 이후에 다시 시도해주세요.");
     }
 
     garden.increaseSunlightCount();

--- a/src/main/java/com/example/cp_main_be/domain/garden/garden/service/GardenService.java
+++ b/src/main/java/com/example/cp_main_be/domain/garden/garden/service/GardenService.java
@@ -159,7 +159,7 @@ public class GardenService {
     LocalDateTime startOfSunlightDay = getStartOfCurrentSunlightDay();
     if (garden.getLastSunlightReceivedAt() != null
         && garden.getLastSunlightReceivedAt().isAfter(startOfSunlightDay)) {
-      throw new IllegalStateException("오늘은 이미 햇빛을 주었습니다. 내일 오전 6시 이후에 다시 시도해주세요.");
+      throw new CustomApiException(ErrorCode.SUNLIGHT_COOL_DOWN,"이미 햇빛을 주었습니다. 내일 오전 6시 이후에 다시 시도해주세요.");
     }
 
     garden.increaseSunlightCount();

--- a/src/main/java/com/example/cp_main_be/global/common/ErrorCode.java
+++ b/src/main/java/com/example/cp_main_be/global/common/ErrorCode.java
@@ -10,11 +10,11 @@ public enum ErrorCode {
   // === 4xx Client Errors ===
   // 400 Bad Request
   INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "E40001", "유효하지 않은 토큰입니다."),
-  WATERING_COOL_DOWN(HttpStatus.BAD_REQUEST, "E40002", "아직 물을 줄 수 없습니다. 8시간이 지나야 가능합니다."),
+  WATERING_COOL_DOWN(HttpStatus.ACCEPTED, "E20002", "아직 물을 줄 수 없습니다."),
   FRIEND_WATERING_LIMIT_EXCEEDED(
       HttpStatus.BAD_REQUEST, "E40003", "오늘은 다른 사람의 정원에 더 이상 물을 줄 수 없습니다."),
-  ALREADY_WATERED_GARDEN(HttpStatus.BAD_REQUEST, "E40004", "이 정원에는 오늘 이미 물을 주었습니다."),
-  SUNLIGHT_COOL_DOWN(HttpStatus.BAD_REQUEST, "E40005", "오늘은 이미 햇빛을 주었습니다."),
+  ALREADY_WATERED_GARDEN(HttpStatus.ACCEPTED, "E20002", "이 정원에는 오늘 이미 물을 주었습니다."),
+  SUNLIGHT_COOL_DOWN(HttpStatus.ACCEPTED, "E20002", "오늘은 이미 햇빛을 주었습니다."),
   GARDEN_SLOT_MAXED_OUT(
       HttpStatus.BAD_REQUEST, "E40006", "더 이상 텃밭을 추가할 수 없습니다."), // 최종 3개 도달 시 사용 가능
   INVALID_FILE(HttpStatus.BAD_REQUEST, "E40007", "적절하지 않은 파일 내용/포맷입니다."),


### PR DESCRIPTION
refactor/물주기 햇빛주기 에러 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- bug fixes
  - 물주기/햇빛주기 쿨다운 및 중복 요청 시 응답을 HTTP 202(ACCEPTED)와 통일된 에러 코드로 반환하도록 수정하고 안내 메시지를 간결화했습니다. 이미 수행된 경우에도 일관된 응답으로 혼선을 줄입니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->