### PR TITLE
refactor: 특정 유저 조회 dto 수정

### DIFF
--- a/src/main/java/com/example/cp_main_be/domain/garden/garden/service/GardenService.java
+++ b/src/main/java/com/example/cp_main_be/domain/garden/garden/service/GardenService.java
@@ -38,13 +38,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class GardenService {
 
-  private final WishTreeService wishTreeService;
-
   private static final int MAX_GARDEN_COUNT = 3;
   private static final Long WATERING_POINTS = 2L;
   private static final Long SUNLIGHT_POINTS = 3L;
   private static final Long MAX_FRIEND_WATERING_PER_DAY = 3L;
-
+  private final WishTreeService wishTreeService;
   private final GardenRepository gardenRepository;
   private final UserService userService;
   private final ApplicationEventPublisher eventPublisher;
@@ -199,6 +197,7 @@ public class GardenService {
           ErrorCode.GARDEN_SLOT_LOCKED, "현재 단계에서는 더 이상 텃밭을 만들 수 없습니다. 소원나무를 성장시켜주세요.");
     }
 
+    // TODO: 여기 뭔가 수정해야할 듯 아바타는 설정해서 가져오고 배경화면은 그냥 기본걸 씀
     // 5. 새로 생성될 텃밭의 기본 배경과 아바타를 설정 (ID 1L을 기본값으로 가정)
     GardenBackground defaultBackground =
         gardenBackgroundRepository

--- a/src/main/java/com/example/cp_main_be/domain/member/user/dto/response/UserGardenDetailResponse.java
+++ b/src/main/java/com/example/cp_main_be/domain/member/user/dto/response/UserGardenDetailResponse.java
@@ -13,8 +13,6 @@ import lombok.Setter;
 @Builder
 public class UserGardenDetailResponse {
   private Long gardenId;
-  private int waterCount;
-  private int maxWaterCount;
   private HomeResponseDto.AvatarInfo avatarInfo; // 해당 정원에 배치된 아바타의 상세 정보
 
   private Boolean isWateringAbleByMe; // 현재 접속 유저가 이 정원에 물을 줄 수 있는지 여부

--- a/src/main/java/com/example/cp_main_be/domain/member/user/dto/response/UserProfileResponse.java
+++ b/src/main/java/com/example/cp_main_be/domain/member/user/dto/response/UserProfileResponse.java
@@ -19,7 +19,7 @@ public class UserProfileResponse {
   // 2: 나를 팔로우 중 (맞팔로우 버튼 보임) - 이 상태는 isFriend가 false일 때만 의미
   private Integer followStatus; // 0: NOT_FOLLOWING, 1: FOLLOWING, 2: FOLLOW_BACK_POSSIBLE
 
-  private int profileUserLevel; // 프로필 주인의 레벨 추가
+  //  private int profileUserLevel; // 프로필 주인의 레벨 추가
   private Long leftWaterCountForOthers; // 오늘 남에게 물을 줄 수 있는 남은 횟수 (현재 접속 유저 기준)
 
   // 프로필 주인의 모든 정원 목록. 각 정원마다 물주기 가능 여부 포함

--- a/src/main/java/com/example/cp_main_be/domain/member/user/service/UserService.java
+++ b/src/main/java/com/example/cp_main_be/domain/member/user/service/UserService.java
@@ -224,8 +224,6 @@ public class UserService {
                   // GardenResponse 대신 UserGardenDetailResponse를 빌드
                   return UserGardenDetailResponse.builder()
                       .gardenId(garden.getId())
-                      .waterCount(garden.getWaterCount())
-                      .maxWaterCount(100)
                       .avatarInfo(avatarInfoForGarden)
                       .isWateringAbleByMe(isWateringAbleByMe)
                       .build();
@@ -238,7 +236,6 @@ public class UserService {
         .userNickname(profileUser.getNickname())
         .profileImageUrl(profileImageUrl)
         .followStatus(followStatus)
-        .profileUserLevel(profileUser.getLevel())
         .leftWaterCountForOthers(leftWaterCountForOthers)
         .userGardens(userGardens)
         .build();

--- a/src/main/java/com/example/cp_main_be/domain/mission/wishTree/WishTreeStage.java
+++ b/src/main/java/com/example/cp_main_be/domain/mission/wishTree/WishTreeStage.java
@@ -10,8 +10,8 @@ public enum WishTreeStage {
   SPROUT(1000L, "새싹", 1L),
   FLOWER(2150L, "꽃", 2L), // 1000 + 1150
   FRUIT(3450L, "열매", 3L), // 2150 + 1300
-  TREE(4900L, "나무", 4L), // 3450 + 1450
-  FINAL(Long.MAX_VALUE, "최종 나무", 5L); // 더 이상 성장 안함
+  TREE(4900L, "나무", 4L), // 3450 + 1450, 최대 텃밭 개수
+  FINAL(Long.MAX_VALUE, "최종 나무", 4L); // 더 이상 성장 안함, 최대 텃밭 개수
 
   private final Long requiredPointsForNextStage;
   private final String koreanName;
@@ -34,7 +34,12 @@ public enum WishTreeStage {
     return values()[this.ordinal() + 1];
   }
 
-  public Long getMaxGardens(WishTreeStage stage) {
-    return stage.maxGardens;
+  /**
+   * 현재 단계에서 가질 수 있는 최대 텃밭 개수를 반환합니다.
+   *
+   * @return 최대 텃밭 개수
+   */
+  public Long getMaxGardens() {
+    return this.maxGardens;
   }
 }


### PR DESCRIPTION
📝 개요
이번 PR의 핵심 내용을 한 줄로 요약해 주세요.


💻 작업 내용
이번 PR에서 작업한 내용을 상세히 설명해 주세요.

작업 내용 1
작업 내용 2
...

✅ PR 체크리스트
PR을 보내기 전에 아래 체크리스트를 확인해 주세요.

커밋 메시지는 포맷에 맞게 작성했나요?
스스로 코드를 다시 한번 검토했나요?
관련 이슈를 연결했나요?
빌드 및 테스트가 로컬에서 성공했나요?

🔗 관련 이슈



스크린샷 (선택)
UI 변경 사항이 있다면 스크린샷을 첨부해 주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 사용자 프로필 응답을 간소화했습니다: 정원 카드에서 물주기 횟수와 최대치 표시를 제거하고, 프로필 레벨 표기를 제외했습니다.
  - 위시트리 단계 정의를 정리하고 최대 텃밭 개수 계산 방식을 단순화했습니다.
- 변경된 동작
  - 최종 단계의 최대 텃밭 개수를 4개로 조정했습니다. 기존·신규 사용자 모두 새 정원 슬롯 추가 한도가 4개로 일관되게 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->