### PR TITLE
Fix/ai 요청 api PNG 리퀘스트로 변경

### DIFF
--- a/src/main/java/com/example/cp_main_be/domain/avatar/image/service/ImageProcessingService.java
+++ b/src/main/java/com/example/cp_main_be/domain/avatar/image/service/ImageProcessingService.java
@@ -131,8 +131,8 @@ public class ImageProcessingService {
                                     new CustomApiException(ErrorCode.AI_AVATAR_FAILED));
                               }))
               .bodyToMono(byte[].class)
-              .timeout(Duration.ofSeconds(30))
-              .block(Duration.ofSeconds(30));
+              .timeout(Duration.ofSeconds(300))
+              .block(Duration.ofSeconds(300));
 
       if (result == null || result.length == 0) {
         log.error("AI 서버에서 유효한 이미지 바이트를 받지 못했습니다 (null/empty).");

--- a/src/main/java/com/example/cp_main_be/domain/avatar/image/service/ImageProcessingService.java
+++ b/src/main/java/com/example/cp_main_be/domain/avatar/image/service/ImageProcessingService.java
@@ -13,6 +13,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -52,16 +54,17 @@ public class ImageProcessingService {
    */
   public String processImageWithAi(MultipartFile imageFile) {
     try {
-      // 1. MultipartFile을 byte 배열로 변환
-      byte[] imageBytes = imageFile.getBytes();
+      // 1. MultipartFile을 MultiValueMap으로 변환하여 multipart-form-data 생성
+      MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+      body.add("image_file", imageFile.getResource()); // FastAPI의 인자명과 동일하게 설정
 
-      // 2. WebClient를 사용하여 바이너리 데이터로 FastAPI 서버에 전송
+      // 2. WebClient를 사용하여 multipart/form-data 형식으로 전송
       byte[] result =
           webClient
               .post()
               .uri(fastapiServerUrl + "/process-image")
-              .contentType(MediaType.APPLICATION_OCTET_STREAM) // 바이너리 데이터로 설정
-              .body(BodyInserters.fromValue(imageBytes)) // 바이트 배열 직접 전송
+              .contentType(MediaType.MULTIPART_FORM_DATA) // multipart/form-data로 설정
+              .body(BodyInserters.fromMultipartData(body)) // MultiValueMap 전송
               .retrieve()
               .onStatus(
                   HttpStatusCode::isError,


### PR DESCRIPTION
Fix/ai 요청 api PNG 리퀘스트로 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 일부 환경에서 이미지 업로드가 간헐적으로 실패하던 문제를 해결하여 전송 안정성을 높였습니다.
  - 처리 흐름을 최적화해 업로드 후 응답 일관성을 향상했습니다.
- 성능/안정성
  - AI 기반 이미지 처리 요청의 최대 대기 시간을 30초에서 300초로 확장해 대용량 이미지와 지연 상황에서도 성공률을 개선했습니다.
  - 타임아웃으로 인한 실패 및 재시도 빈도를 줄였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->