### PR TITLE
Fix/ai 요청 api url 출력으로 변경

### DIFF
--- a/src/main/java/com/example/cp_main_be/domain/avatar/image/AiResponseDTO.java
+++ b/src/main/java/com/example/cp_main_be/domain/avatar/image/AiResponseDTO.java
@@ -1,0 +1,8 @@
+package com.example.cp_main_be.domain.avatar.image;
+
+import lombok.Getter;
+
+@Getter
+public class AiResponseDTO {
+    String imageUrl;
+}

--- a/src/main/java/com/example/cp_main_be/domain/avatar/image/service/ImageProcessingService.java
+++ b/src/main/java/com/example/cp_main_be/domain/avatar/image/service/ImageProcessingService.java
@@ -131,8 +131,8 @@ public class ImageProcessingService {
                                     new CustomApiException(ErrorCode.AI_AVATAR_FAILED));
                               }))
               .bodyToMono(byte[].class)
-              .timeout(Duration.ofSeconds(30))
-              .block(Duration.ofSeconds(30));
+              .timeout(Duration.ofSeconds(300))
+              .block(Duration.ofSeconds(300));
 
       if (result == null || result.length == 0) {
         log.error("AI 서버에서 유효한 이미지 바이트를 받지 못했습니다 (null/empty).");

--- a/src/main/java/com/example/cp_main_be/domain/avatar/image/service/ImageProcessingService.java
+++ b/src/main/java/com/example/cp_main_be/domain/avatar/image/service/ImageProcessingService.java
@@ -1,5 +1,6 @@
 package com.example.cp_main_be.domain.avatar.image.service;
 
+import com.example.cp_main_be.domain.avatar.image.AiResponseDTO;
 import com.example.cp_main_be.global.common.CustomApiException;
 import com.example.cp_main_be.global.common.ErrorCode;
 import com.example.cp_main_be.global.infra.StorageService;
@@ -10,8 +11,10 @@ import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.MultipartBodyBuilder;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -54,17 +57,19 @@ public class ImageProcessingService {
    */
   public String processImageWithAi(MultipartFile imageFile) {
     try {
-      // 1. MultipartFile을 MultiValueMap으로 변환하여 multipart-form-data 생성
-      MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
-      body.add("image_file", imageFile.getResource()); // FastAPI의 인자명과 동일하게 설정
+      MultipartBodyBuilder bodyBuilder = new MultipartBodyBuilder();
+      bodyBuilder.part("image_file", new ByteArrayResource(imageFile.getBytes()))
+              .filename(imageFile.getOriginalFilename()) // 원래 파일명 사용
+              .contentType(MediaType.parseMediaType(imageFile.getContentType())); // 원본 Content-Type 유지
 
+// WebClient 요청 시
       // 2. WebClient를 사용하여 multipart/form-data 형식으로 전송
-      byte[] result =
+      AiResponseDTO result =
           webClient
               .post()
               .uri(fastapiServerUrl + "/process-image")
               .contentType(MediaType.MULTIPART_FORM_DATA) // multipart/form-data로 설정
-              .body(BodyInserters.fromMultipartData(body)) // MultiValueMap 전송
+                  .body(BodyInserters.fromMultipartData(bodyBuilder.build()))
               .retrieve()
               .onStatus(
                   HttpStatusCode::isError,
@@ -80,20 +85,21 @@ public class ImageProcessingService {
                                 return Mono.error(
                                     new CustomApiException(ErrorCode.AI_AVATAR_FAILED));
                               }))
-              .bodyToMono(byte[].class)
-              .timeout(Duration.ofSeconds(30))
-              .block(Duration.ofSeconds(30));
+//                  .bodyToMono(byte[].class)
+              .bodyToMono(AiResponseDTO.class)
+              .timeout(Duration.ofSeconds(300))
+              .block(Duration.ofSeconds(300));
 
-      if (result == null || result.length == 0) {
-        log.error("AI 서버에서 유효한 이미지 바이트를 받지 못했습니다 (null/empty).");
+      if (result == null || result.getImageUrl().isEmpty()) {
+        log.error("AI 서버에서 유효한 이미지 링크를 받지 못했습니다 (null/empty).");
         throw new CustomApiException(ErrorCode.AI_AVATAR_FAILED);
       }
 
       // 3. 받은 byte 배열을 스토리지에 업로드하고 URL을 받음
-      String imageUrl =
-          storageService.uploadFile(result, "avatars/", imageFile.getOriginalFilename());
+//      String imageUrl =
+//          storageService.uploadFile(result, "avatars/", imageFile.getOriginalFilename());
 
-      return imageUrl;
+      return result.getImageUrl();
 
     } catch (Exception e) {
       // 실패 시 폴백 URL 리스트에서 랜덤으로 하나를 선택하여 반환

--- a/src/main/java/com/example/cp_main_be/domain/avatar/image/service/ImageProcessingService.java
+++ b/src/main/java/com/example/cp_main_be/domain/avatar/image/service/ImageProcessingService.java
@@ -13,6 +13,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -52,16 +54,17 @@ public class ImageProcessingService {
    */
   public String processImageWithAi(MultipartFile imageFile) {
     try {
-      // 1. MultipartFile을 byte 배열로 변환
-      byte[] imageBytes = imageFile.getBytes();
+      // 1. MultipartFile을 MultiValueMap으로 변환하여 multipart-form-data 생성
+      MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+      body.add("image_file", imageFile.getResource()); // FastAPI의 인자명과 동일하게 설정
 
-      // 2. WebClient를 사용하여 바이너리 데이터로 FastAPI 서버에 전송
+      // 2. WebClient를 사용하여 multipart/form-data 형식으로 전송
       byte[] result =
           webClient
               .post()
               .uri(fastapiServerUrl + "/process-image")
-              .contentType(MediaType.APPLICATION_OCTET_STREAM) // 바이너리 데이터로 설정
-              .body(BodyInserters.fromValue(imageBytes)) // 바이트 배열 직접 전송
+              .contentType(MediaType.MULTIPART_FORM_DATA) // multipart/form-data로 설정
+              .body(BodyInserters.fromMultipartData(body)) // MultiValueMap 전송
               .retrieve()
               .onStatus(
                   HttpStatusCode::isError,


### PR DESCRIPTION
Fix/ai 요청 api 스트링 출력으로 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

• Refactor
  • AI 이미지 처리 결과를 바이트 전송·스토리지 업로드 대신 AI 서버의 최종 이미지 URL로 직접 반환하도록 전환해 결과 접근성을 높이고 응답 흐름을 단순화했습니다.
  • 원본 파일명과 콘텐츠 타입을 보존해 전송 신뢰성을 개선했습니다.
  • URL 기반 응답 검증으로 오류 메시지와 로그 가독성을 개선했습니다.
  • 이미지 생성 후 결과 링크 수신이 더 일관되고 빠르게 제공됩니다.
  • 기존 기능과 호환성을 유지했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->